### PR TITLE
Add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.tmp
+testRunner
+example/hello
+.depend

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,9 @@ TARGET = example/hello
 #  Flags
 # ------------------------------------------------------------
 SMLSHARP = smlsharp
-SMLSHARP_CFLAGS = -O2 -I lib
-SMLSHARP_LDFLAGS = -I lib
+SMLSHARP_FLAGS = -I lib
+SMLSHARP_CFLAGS = -O2
+SMLSHARP_LDFLAGS =
 CFLAGS += -m32
 
 # ------------------------------------------------------------
@@ -58,10 +59,10 @@ example_objects := $(example_sources:.sml=.o)
 all: $(TARGET)
 
 $(TARGET): $(example_objects) $(objects) $(c_objects)
-	$(SMLSHARP) $(SMLSHARP_LDFLAGS) -o $@ example/$(EXAMPLE_MAIN).smi $(c_objects)
+	$(SMLSHARP) $(SMLSHARP_LDFLAGS) $(SMLSHARP_FLAGS) -o $@ example/$(EXAMPLE_MAIN).smi $(c_objects)
 
 $(TEST_TARGET): $(objects) $(c_objects) $(lib_objects) $(test_objects)
-	$(SMLSHARP) $(SMLSHARP_LDFLAGS) -o $@ test/Main.smi $(c_objects)
+	$(SMLSHARP) $(SMLSHARP_LDFLAGS) $(SMLSHARP_FLAGS) -o $@ test/Main.smi $(c_objects)
 
 check: $(TEST_TARGET)
 	./$(TEST_TARGET)
@@ -74,7 +75,7 @@ clean:
 #  Build rules
 # ------------------------------------------------------------
 %.o: %.sml
-	$(SMLSHARP) $(SMLSHARP_CFLAGS) -c -o $@ $<
+	$(SMLSHARP) $(SMLSHARP_CFLAGS) $(SMLSHARP_FLAGS) -c -o $@ $<
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(DEFS) $(CPPFLAGS) -c -o $@ $<
@@ -85,5 +86,5 @@ clean:
 .PHONY: depend
 
 depend:
-	$(SMLSHARP) -MM $(sources) $(test_sources) $(lib_sources) > .depend
+	$(SMLSHARP) $(SMLSHARP_FLAGS) -MM $(sources) $(test_sources) $(lib_sources) > .depend
 -include .depend

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+# ------------------------------------------------------------
+#  configure for lib/
+# ------------------------------------------------------------
+# SML files
+MODULES = \
+	ext/Std
+
+# C files
+C_MODULES = \
+
+# ------------------------------------------------------------
+#  configure for test
+# ------------------------------------------------------------
+#  (TBD)
+TEST_MODULES = \
+	Main \
+	ext/StdTest
+
+TEST_TARGET = testRunner
+
+# ------------------------------------------------------------
+#  configure for test
+# ------------------------------------------------------------
+EXAMPLE_MODULES = \
+	hello
+
+EXAMPLE_MAIN = hello
+
+TARGET = example/hello
+
+# ------------------------------------------------------------
+#  Flags
+# ------------------------------------------------------------
+SMLSHARP = smlsharp
+SMLSHARP_CFLAGS = -O2 -I lib
+SMLSHARP_LDFLAGS = -I lib
+CFLAGS += -m32
+
+# ------------------------------------------------------------
+#  prepare variables
+# ------------------------------------------------------------
+sources := $(addprefix lib/,$(MODULES:=.sml))
+objects := $(sources:.sml=.o)
+
+c_sources = $(addprefix lib/,$(C_MODULES:=.c))
+c_objects := $(c_sources:.c=.o)
+
+test_sources := $(addprefix test/, $(TEST_MODULES:=.sml))
+test_objects := $(test_sources:.sml=.o)
+
+example_sources := $(addprefix example/, $(EXAMPLE_MODULES:=.sml))
+example_objects := $(example_sources:.sml=.o)
+
+# ------------------------------------------------------------
+#  Build target
+# ------------------------------------------------------------
+.PHONY: all clean check
+all: $(TARGET)
+
+$(TARGET): $(example_objects) $(objects) $(c_objects)
+	$(SMLSHARP) $(SMLSHARP_LDFLAGS) -o $@ example/$(EXAMPLE_MAIN).smi $(c_objects)
+
+$(TEST_TARGET): $(objects) $(c_objects) $(lib_objects) $(test_objects)
+	$(SMLSHARP) $(SMLSHARP_LDFLAGS) -o $@ test/Main.smi $(c_objects)
+
+check: $(TEST_TARGET)
+	./$(TEST_TARGET)
+
+clean:
+	find . -name '*.o' | xargs rm -rf
+	rm -rf $(TARGET) $(TEST_TARGET)
+
+# ------------------------------------------------------------
+#  Build rules
+# ------------------------------------------------------------
+%.o: %.sml
+	$(SMLSHARP) $(SMLSHARP_CFLAGS) -c -o $@ $<
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(DEFS) $(CPPFLAGS) -c -o $@ $<
+
+# ------------------------------------------------------------
+#  Dependencies
+# ------------------------------------------------------------
+.PHONY: depend
+
+depend:
+	$(SMLSHARP) -MM $(sources) $(test_sources) $(lib_sources) > .depend
+-include .depend

--- a/README.md
+++ b/README.md
@@ -11,3 +11,28 @@ TBD
  * モジュールは階層構造をせずにフラットにする
  * [1モジュール1データ型主義](http://d.hatena.ne.jp/camlspotter/20121216/1355686499)を採用する
 
+## ビルド方法
+### exampleのビルド
+`make all` で `example/` 以下のファイルをビルドできます。
+
+```shell
+$ make depend
+$ make all
+```
+
+実行:
+
+```shell
+$ ./example/hello
+```
+
+### テストの実行
+
+```shell
+$ make check
+./testRunner
+.
+tests = 1, failures = 0, errors = 0
+Failures:
+Errors:
+```

--- a/example/hello.smi
+++ b/example/hello.smi
@@ -1,0 +1,2 @@
+_require "basis.smi"
+_require "ext/Std.smi"

--- a/example/hello.sml
+++ b/example/hello.sml
@@ -1,0 +1,2 @@
+val () =
+  print "hello, world\n"

--- a/lib/ext/Std.smi
+++ b/lib/ext/Std.smi
@@ -1,0 +1,5 @@
+structure Std = struct
+  val id : 'a -> 'a
+  val version : (int * int * int)
+  val version_string : string
+end

--- a/lib/ext/Std.sml
+++ b/lib/ext/Std.sml
@@ -1,0 +1,6 @@
+structure Std = struct
+  fun id x = x
+
+  val version = (0,1,0)
+  val version_string = "0.1.0"
+end

--- a/test/Main.smi
+++ b/test/Main.smi
@@ -1,0 +1,3 @@
+_require "basis.smi"
+_require "smlunit-lib.smi"
+_require "./ext/StdTest.smi"

--- a/test/Main.sml
+++ b/test/Main.sml
@@ -1,0 +1,9 @@
+val suites = SMLUnit.Test.TestList [
+  StdTest.suite ()
+]
+
+val () =
+  SMLUnit.TextUITestRunner.runTest {output = TextIO.stdOut} suites
+
+val () =
+  OS.Process.exit OS.Process.success

--- a/test/ext/StdTest.smi
+++ b/test/ext/StdTest.smi
@@ -1,0 +1,7 @@
+_require "basis.smi"
+_require "smlunit-lib.smi"
+_require "ext/Std.smi"
+
+structure StdTest = struct
+  val suite : unit -> SMLUnit.Test.test
+end

--- a/test/ext/StdTest.sml
+++ b/test/ext/StdTest.sml
@@ -1,0 +1,10 @@
+structure StdTest = struct
+  open SMLUnit
+
+  fun id_test () =
+    Assert.assertEqualInt 42 (Std.id 42)
+
+  fun suite _ = Test.labelTests [
+    ("id test", id_test)
+  ]
+end


### PR DESCRIPTION
Makefileを導入して、ビルドできるようにしました。ついでにSMLUnitによるテストも実行可能です。
## ファイルレイアウト

```
.
├── LICENSE
├── Makefile
├── README.md
├── example # 動作サンプル
│   ├── hello.smi
│   └── hello.sml
├── lib # ライブラリ本体
│   └── ext
│       ├── Std.smi
│       └── Std.sml
└── test # 単体テスト
    ├── Main.smi
    ├── Main.sml
    └── ext
        ├── StdTest.smi
        └── StdTest.sml
```
## 使い方

see https://github.com/bleis-tift/SmlSharpContrib/blob/647ff806e4187824f9296547cf1d6e0c1bc9ae24/README.md
## 相談したいこと
- ファイル名の命名規約。(LikeThis.sml or likeThis.sml or like_this.sml) SML#本体はLikeThis.smlっぽい。
- ディレクトリ構成、これでいいかな?
## (まだ)やらないこと
- 配布に適した形(libsmlcontrib.aとか?)はまだ作らない
- CIサービスとの連携
