### PR TITLE
Implement Set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # SML files
 MODULES = \
 	ext/Std \
+	ext/Set \
 	parser/Parser
 
 # C files
@@ -16,6 +17,7 @@ C_MODULES = \
 TEST_MODULES = \
 	Main \
 	ext/StdTest \
+	ext/SetTest \
 	parser/ParserTest
 
 TEST_TARGET = testRunner

--- a/lib/ext/Set.smi
+++ b/lib/ext/Set.smi
@@ -1,0 +1,38 @@
+_require "basis.smi"
+
+functor Set 
+  (X : sig 
+         type t 
+
+         val compare : t * t -> order
+       end
+  ) =
+struct
+  type elt = X.t
+  type t (= boxed)
+  
+  val empty : t
+  val is_empty : t -> bool
+  val mem : X.t -> t -> bool
+  val min_elt : t -> elt option
+  val max_elt : t -> elt option
+  val choose : t -> elt option
+  val fold : (elt * 'a -> 'a) -> t -> 'a -> 'a
+  val elements : t -> X.t list
+  val rev_elements : t -> X.t list
+  val cardinal : t -> int
+  val for_all : (elt -> bool) -> t -> bool
+  val exists : (elt -> bool) -> t -> bool
+  val compare : t * t -> order
+  val equal : t * t -> bool
+  val subset : t * t -> bool
+  val singleton : X.t -> t
+  val add : X.t -> t -> t
+  val remove : X.t -> t -> t
+  val split : X.t -> t -> {in_:bool, left:t, right:t}
+  val inter : t * t -> t
+  val diff : t * t -> t
+  val union : t * t -> t
+  val filter : (elt -> bool) -> t -> t
+  val partition : (elt -> bool) -> t -> t * t
+end

--- a/lib/ext/Set.smi
+++ b/lib/ext/Set.smi
@@ -12,16 +12,16 @@ struct
   type t (= boxed)
   
   val empty : t
-  val is_empty : t -> bool
+  val isEmpty : t -> bool
   val mem : X.t -> t -> bool
-  val min_elt : t -> elt option
-  val max_elt : t -> elt option
+  val minElt : t -> elt option
+  val maxElt : t -> elt option
   val choose : t -> elt option
   val fold : (elt * 'a -> 'a) -> t -> 'a -> 'a
   val elements : t -> X.t list
-  val rev_elements : t -> X.t list
+  val revElements : t -> X.t list
   val cardinal : t -> int
-  val for_all : (elt -> bool) -> t -> bool
+  val forall : (elt -> bool) -> t -> bool
   val exists : (elt -> bool) -> t -> bool
   val compare : t * t -> order
   val equal : t * t -> bool
@@ -29,10 +29,10 @@ struct
   val singleton : X.t -> t
   val add : X.t -> t -> t
   val remove : X.t -> t -> t
-  val split : X.t -> t -> {in_:bool, left:t, right:t}
+  val split : X.t -> t -> { present : bool, less : t, greater : t }
   val inter : t * t -> t
   val diff : t * t -> t
   val union : t * t -> t
   val filter : (elt -> bool) -> t -> t
-  val partition : (elt -> bool) -> t -> t * t
+  val partition : (elt -> bool) -> t -> { satisfy : t, dissatisfy : t }
 end

--- a/lib/ext/Set.sml
+++ b/lib/ext/Set.sml
@@ -16,10 +16,10 @@ struct
   
   val empty = LEAF
   
-  (** val is_empty : tree -> bool **)
+  (** val isEmpty : tree -> bool **)
   
-  fun is_empty LEAF = true
-    | is_empty (NODE _) = false
+  fun isEmpty LEAF = true
+    | isEmpty (NODE _) = false
   
   (** val mem : X.t -> tree -> bool **)
   
@@ -30,21 +30,21 @@ struct
         | LESS => mem x l
         | GREATER => mem x r
   
-  (** val min_elt : tree -> elt option **)
+  (** val minElt : tree -> elt option **)
   
-  fun min_elt LEAF = NONE
-    | min_elt (NODE (_, LEAF, x, _)) = SOME x
-    | min_elt (NODE (_, l as NODE _, x, _)) = min_elt l
+  fun minElt LEAF = NONE
+    | minElt (NODE (_, LEAF, x, _)) = SOME x
+    | minElt (NODE (_, l as NODE _, x, _)) = minElt l
   
-  (** val max_elt : tree -> elt option **)
+  (** val maxElt : tree -> elt option **)
   
-  fun max_elt LEAF = NONE
-    | max_elt (NODE (_, _, x, LEAF)) = SOME x
-    | max_elt (NODE (_, _, x, r as NODE _)) = max_elt r
+  fun maxElt LEAF = NONE
+    | maxElt (NODE (_, _, x, LEAF)) = SOME x
+    | maxElt (NODE (_, _, x, r as NODE _)) = maxElt r
   
   (** val choose : tree -> elt option **)
   
-  val choose = min_elt
+  val choose = minElt
   
   (** val fold : (elt * 'a1 -> 'a1) -> tree -> 'a1 -> 'a1 **)
   
@@ -52,36 +52,36 @@ struct
     | fold f (NODE (_, l, x, r)) base =
         fold f r (f (x, fold f l base))
   
-  (** val elements_aux : X.t list -> tree -> X.t list **)
+  (** val elementsAux : X.t list -> tree -> X.t list **)
   
-  fun elements_aux acc LEAF = acc
-    | elements_aux acc (NODE (_, l, x, r)) =
-        elements_aux (x :: elements_aux acc r) l
+  fun elementsAux acc LEAF = acc
+    | elementsAux acc (NODE (_, l, x, r)) =
+        elementsAux (x :: elementsAux acc r) l
   
   (** val elements : tree -> X.t list **)
   
-  val elements = elements_aux []
+  val elements = elementsAux []
   
-  (** val rev_elements_aux : X.t list -> tree -> X.t list **)
+  (** val revElementsAux : X.t list -> tree -> X.t list **)
   
-  fun rev_elements_aux acc LEAF = acc
-    | rev_elements_aux acc (NODE (_, l, x, r)) =
-        rev_elements_aux (x :: rev_elements_aux acc l) r
+  fun revElementsAux acc LEAF = acc
+    | revElementsAux acc (NODE (_, l, x, r)) =
+        revElementsAux (x :: revElementsAux acc l) r
   
-  (** val rev_elements : tree -> X.t list **)
+  (** val revElements : tree -> X.t list **)
   
-  val rev_elements = rev_elements_aux []
+  val revElements = revElementsAux []
   
   (** val cardinal : tree -> int **)
   
   fun cardinal LEAF = 0
     | cardinal (NODE (_, l, _, r)) = 1 + cardinal l + cardinal r
   
-  (** val for_all : (elt -> bool) -> tree -> bool **)
+  (** val forall : (elt -> bool) -> tree -> bool **)
   
-  fun for_all f LEAF = true
-    | for_all f (NODE (_, l, x, r)) =
-        f x andalso for_all f l andalso for_all f r
+  fun forall f LEAF = true
+    | forall f (NODE (_, l, x, r)) =
+        f x andalso forall f l andalso forall f r
   
   (** val exists : (elt -> bool) -> tree -> bool **)
   
@@ -99,31 +99,31 @@ struct
     | cons (NODE (_, l, x, r)) e =
         cons l (MORE (x, r, e))
   
-  (** val compare_more :
+  (** val compareMore :
       X.t -> (enumeration -> order) -> enumeration -> order **)
   
-  fun compare_more x1 cont END = GREATER
-    | compare_more x1 cont (MORE (x2, r2, e3)) =
+  fun compareMore x1 cont END = GREATER
+    | compareMore x1 cont (MORE (x2, r2, e3)) =
         case X.compare (x1, x2) of
           EQUAL => cont (cons r2 e3)
         | x => x
   
-  (** val compare_cont :
+  (** val compareCont :
       tree -> (enumeration -> order) -> enumeration -> order **)
   
-  fun compare_cont LEAF cont e2 = cont e2
-    | compare_cont (NODE (_, l1, x1, r1)) cont e2 =
-        compare_cont l1 (compare_more x1 (compare_cont r1 cont)) e2
+  fun compareCont LEAF cont e2 = cont e2
+    | compareCont (NODE (_, l1, x1, r1)) cont e2 =
+        compareCont l1 (compareMore x1 (compareCont r1 cont)) e2
   
-  (** val compare_end : enumeration -> order **)
+  (** val compareEnd : enumeration -> order **)
   
-  fun compare_end END = EQUAL
-    | compare_end (MORE _) = LESS
+  fun compareEnd END = EQUAL
+    | compareEnd (MORE _) = LESS
   
   (** val compare : tree * tree -> order **)
   
   fun compare (s1, s2) =
-    compare_cont s1 compare_end (cons s2 END)
+    compareCont s1 compareEnd (cons s2 END)
   
   (** val equal : tree * tree -> bool **)
   
@@ -226,24 +226,24 @@ struct
   fun join LEAF x = add x
     | join (l as NODE (lh, ll, lx, lr)) x =
         let
-          fun join_aux LEAF = add x l
-            | join_aux (r as NODE (rh, rl, rx, rr)) =
+          fun joinAux LEAF = add x l
+            | joinAux (r as NODE (rh, rl, rx, rr)) =
                 if lh > rh + 2 then
                   bal ll lx (join lr x r)
                 else if rh > lh + 2 then
-                  bal (join_aux rl) rx rr
+                  bal (joinAux rl) rx rr
                 else
                   create l x r
         in
-          join_aux
+          joinAux
         end
   
-  (** val remove_min : tree -> elt -> t -> t * elt **)
+  (** val removeMin : tree -> elt -> t -> t * elt **)
   
-  fun remove_min LEAF x r = (r, x)
-    | remove_min (NODE (_, ll, lx, lr)) x r =
+  fun removeMin LEAF x r = (r, x)
+    | removeMin (NODE (_, ll, lx, lr)) x r =
         let
-          val (l', m) = remove_min ll lx lr
+          val (l', m) = removeMin ll lx lr
         in
           (bal l' x r, m)
         end
@@ -254,7 +254,7 @@ struct
     | merge (s1, LEAF) = s1
     | merge (s1 as NODE _, NODE (_, l2, x2, r2)) =
         let
-          val (s2', m) = remove_min l2 x2 r2
+          val (s2', m) = removeMin l2 x2 r2
         in
           bal s1 m s2'
         end
@@ -274,24 +274,24 @@ struct
     | concat (s1, LEAF) = s1
     | concat (s1, NODE (_, l2, x2, r2)) =
         let
-          val (s2', m) = remove_min l2 x2 r2
+          val (s2', m) = removeMin l2 x2 r2
         in
           join s1 m s2'
         end
 
-  (** val split : X.t -> tree -> { left : t, in : bool, right : t } **)
+  (** val split : X.t -> tree -> { less : t, present : bool, greater : t } **)
   
-  fun split x LEAF = { left = LEAF, in_ = false, right = LEAF }
+  fun split x LEAF = { less = LEAF, present = false, greater = LEAF }
     | split x (NODE (_, l, y, r)) =
         case X.compare (x, y) of
-          EQUAL => { left = l, in_ = true, right = r }
+          EQUAL => { less = l, present = true, greater = r }
         | LESS =>
-            let val { left = ll, in_ = b, right = rl } = split x l in
-              { left = ll, in_ = b, right = (join rl y r) }
+            let val { less = ll, present = b, greater = rl } = split x l in
+              { less = ll, present = b, greater = (join rl y r) }
             end
         | GREATER =>
-            let val { left = rl, in_ = b, right = rr } = split x r in
-              { left = (join l y rl), in_ = b, right = rr }
+            let val { less = rl, present = b, greater = rr } = split x r in
+              { less = (join l y rl), present = b, greater = rr }
             end
   
   (** val inter : tree * tree -> tree **)
@@ -300,7 +300,7 @@ struct
     | inter (s1, LEAF) = LEAF
     | inter (NODE (_, l1, x1, r1), s2 as NODE _) =
         let
-          val { left = l2', in_ = pres, right = r2' } = split x1 s2
+          val { less = l2', present = pres, greater = r2' } = split x1 s2
         in
           if pres then
             join (inter (l1, l2')) x1 (inter (r1, r2'))
@@ -314,7 +314,7 @@ struct
     | diff (s1, LEAF) = s1
     | diff (NODE (_, l1, x1, r1), s2 as NODE _) =
         let
-          val { left = l2', in_ = pres, right = r2' } = split x1 s2
+          val { less = l2', present = pres, greater = r2' } = split x1 s2
         in
           if pres then
             concat (diff (l1, l2'), diff (r1, r2'))
@@ -328,7 +328,7 @@ struct
     | union (s1, LEAF) = s1
     | union (NODE (_, l1, x1, r1), s2 as NODE _) =
         let
-          val { left = l2', in_ = x, right = r2' } = split x1 s2
+          val { less = l2', present = x, greater = r2' } = split x1 s2
         in
           join (union (l1, l2')) x1 (union (r1, r2'))
         end
@@ -344,17 +344,17 @@ struct
            if f x then join l' x r' else concat (l', r')
          end
   
-  (** val partition : (elt -> bool) -> t -> t * t **)
+  (** val partition : (elt -> bool) -> t -> { satisfy : t, dissatisfy : t } **)
   
-  fun partition f LEAF = (LEAF, LEAF)
+  fun partition f LEAF = { satisfy = LEAF, dissatisfy = LEAF }
     | partition f (NODE (_, l, x, r)) =
         let
-          val (l1, l2) = partition f l
-          val (r1, r2) = partition f r
+          val { satisfy = l1, dissatisfy = l2 } = partition f l
+          val { satisfy = r1, dissatisfy = r2 } = partition f r
         in
           if f x then
-            (join l1 x r1, concat (l2, r2))
+            { satisfy = join l1 x r1, dissatisfy = concat (l2, r2) }
           else
-            (concat (l1, r1), join l2 x r2)
+            { satisfy = concat (l1, r1), dissatisfy = join l2 x r2 }
         end
 end

--- a/lib/ext/Set.sml
+++ b/lib/ext/Set.sml
@@ -1,0 +1,360 @@
+functor Set
+  (X : sig 
+       type t 
+
+       val compare : t * t -> order
+     end
+  ) = 
+struct 
+  type elt = X.t
+  
+  datatype tree =
+    LEAF
+  | NODE of int * tree * X.t * tree
+  
+  (** val empty : tree **)
+  
+  val empty = LEAF
+  
+  (** val is_empty : tree -> bool **)
+  
+  fun is_empty LEAF = true
+    | is_empty (NODE _) = false
+  
+  (** val mem : X.t -> tree -> bool **)
+  
+  fun mem x LEAF = false
+    | mem x (NODE (_, l, k, r)) =
+        case X.compare (x, k) of
+          EQUAL => true
+        | LESS => mem x l
+        | GREATER => mem x r
+  
+  (** val min_elt : tree -> elt option **)
+  
+  fun min_elt LEAF = NONE
+    | min_elt (NODE (_, LEAF, x, _)) = SOME x
+    | min_elt (NODE (_, l as NODE _, x, _)) = min_elt l
+  
+  (** val max_elt : tree -> elt option **)
+  
+  fun max_elt LEAF = NONE
+    | max_elt (NODE (_, _, x, LEAF)) = SOME x
+    | max_elt (NODE (_, _, x, r as NODE _)) = max_elt r
+  
+  (** val choose : tree -> elt option **)
+  
+  val choose = min_elt
+  
+  (** val fold : (elt * 'a1 -> 'a1) -> tree -> 'a1 -> 'a1 **)
+  
+  fun fold f LEAF base = base
+    | fold f (NODE (_, l, x, r)) base =
+        fold f r (f (x, fold f l base))
+  
+  (** val elements_aux : X.t list -> tree -> X.t list **)
+  
+  fun elements_aux acc LEAF = acc
+    | elements_aux acc (NODE (_, l, x, r)) =
+        elements_aux (x :: elements_aux acc r) l
+  
+  (** val elements : tree -> X.t list **)
+  
+  val elements = elements_aux []
+  
+  (** val rev_elements_aux : X.t list -> tree -> X.t list **)
+  
+  fun rev_elements_aux acc LEAF = acc
+    | rev_elements_aux acc (NODE (_, l, x, r)) =
+        rev_elements_aux (x :: rev_elements_aux acc l) r
+  
+  (** val rev_elements : tree -> X.t list **)
+  
+  val rev_elements = rev_elements_aux []
+  
+  (** val cardinal : tree -> int **)
+  
+  fun cardinal LEAF = 0
+    | cardinal (NODE (_, l, _, r)) = 1 + cardinal l + cardinal r
+  
+  (** val for_all : (elt -> bool) -> tree -> bool **)
+  
+  fun for_all f LEAF = true
+    | for_all f (NODE (_, l, x, r)) =
+        f x andalso for_all f l andalso for_all f r
+  
+  (** val exists : (elt -> bool) -> tree -> bool **)
+  
+  fun exists f LEAF = false
+    | exists f (NODE (_, l, x, r)) =
+        f x orelse exists f l orelse exists f r
+  
+  datatype enumeration =
+    END
+  | MORE of elt * tree * enumeration
+  
+  (** val cons : tree -> enumeration -> enumeration **)
+  
+  fun cons LEAF e = e
+    | cons (NODE (_, l, x, r)) e =
+        cons l (MORE (x, r, e))
+  
+  (** val compare_more :
+      X.t -> (enumeration -> order) -> enumeration -> order **)
+  
+  fun compare_more x1 cont END = GREATER
+    | compare_more x1 cont (MORE (x2, r2, e3)) =
+        case X.compare (x1, x2) of
+          EQUAL => cont (cons r2 e3)
+        | x => x
+  
+  (** val compare_cont :
+      tree -> (enumeration -> order) -> enumeration -> order **)
+  
+  fun compare_cont LEAF cont e2 = cont e2
+    | compare_cont (NODE (_, l1, x1, r1)) cont e2 =
+        compare_cont l1 (compare_more x1 (compare_cont r1 cont)) e2
+  
+  (** val compare_end : enumeration -> order **)
+  
+  fun compare_end END = EQUAL
+    | compare_end (MORE _) = LESS
+  
+  (** val compare : tree * tree -> order **)
+  
+  fun compare (s1, s2) =
+    compare_cont s1 compare_end (cons s2 END)
+  
+  (** val equal : tree * tree -> bool **)
+  
+  fun equal (s1, s2) =
+    case compare (s1, s2) of
+      EQUAL => true
+    | _ => false
+  
+  (** val subsetl : (tree -> bool) -> X.t -> tree -> bool **)
+  
+  fun subsetl subset_l1 x1 LEAF = false
+    | subsetl subset_l1 x1 (s2 as NODE (_, l2, x2, r2)) =
+        case X.compare (x1, x2) of
+          EQUAL => subset_l1 l2
+        | LESS => subsetl subset_l1 x1 l2
+        | GREATER => mem x1 r2 andalso subset_l1 s2
+  
+  (** val subsetr : (tree -> bool) -> X.t -> tree -> bool **)
+  
+  fun subsetr subset_r1 x1 LEAF = false
+    | subsetr subset_r1 x1 (s2 as NODE (_, l2, x2, r2)) =
+        case X.compare (x1, x2) of
+          EQUAL => subset_r1 r2
+        | LESS => mem x1 l2 andalso subset_r1 s2 
+        | GREATER => subsetr subset_r1 x1 r2
+  
+  (** val subset : tree -> tree -> bool **)
+  
+  fun subset (LEAF, s2) = true
+    | subset (s1, LEAF) = false
+    | subset (NODE (_, l1, x1, r1), s2 as NODE (_, l2, x2, r2)) =
+        case X.compare (x1, x2) of
+          EQUAL => subset (l1, l2) andalso subset (r1, r2)
+        | LESS => subsetl (fn s => subset (l1, s)) x1 l2 andalso subset (r1, s2)
+        | GREATER => subsetr (fn s => subset (r1, s)) x1 r2 andalso subset (l1, s2) 
+  type t = tree
+  
+  (** val height : tree -> int **)
+  
+  fun height LEAF = 0
+    | height (NODE (h, _, _, _)) = h
+  
+  (** val singleton : X.t -> tree **)
+  
+  fun singleton x = NODE (1, LEAF, x, LEAF)
+  
+  (** val create : t -> X.t -> t -> tree **)
+  
+  fun create l x r =
+    NODE (Int.max (height l, height r) + 1, l, x, r)
+  
+  (** val assert_false : t -> X.t -> t -> tree **)
+  
+  val assert_false = create
+  
+  (** val bal : t -> X.t -> t -> tree **)
+  
+  fun bal l x r =
+    let
+      val hl = height l
+      val hr = height r
+    in
+      if hl > hr + 2 then
+        case l of
+          LEAF => assert_false l x r
+        | NODE (_, ll, lx, lr) =>
+            if height ll >= height lr then
+              create ll lx (create lr x r)
+            else
+              case lr of
+                LEAF => assert_false l x r
+              | NODE (_, lrl, lrx, lrr) =>
+                  create (create ll lx lrl) lrx (create lrr x r)
+      else if hr > hl + 2 then
+        case r of
+          LEAF => assert_false l x r
+        | NODE (_, rl, rx, rr) =>
+            if height rr >= height rl then
+              create (create l x rl) rx rr
+            else
+              case rl of
+                LEAF => assert_false l x r
+              | NODE (_, rll, rlx, rlr) =>
+                  create (create l x rll) rlx (create rlr rx rr)
+      else
+        create l x r
+    end
+  
+  (** val add : X.t -> tree -> tree **)
+  
+  fun add x LEAF = NODE (1, LEAF, x, LEAF)
+    | add x (NODE (h, l, y, r)) =
+        case X.compare (x, y) of
+          EQUAL => NODE (h, l, y, r)
+        | LESS => bal (add x l) y r
+        | GREATER => bal l y (add x r)
+  
+  (** val join : tree -> elt -> t -> t **)
+  
+  fun join LEAF x = add x
+    | join (l as NODE (lh, ll, lx, lr)) x =
+        let
+          fun join_aux LEAF = add x l
+            | join_aux (r as NODE (rh, rl, rx, rr)) =
+                if lh > rh + 2 then
+                  bal ll lx (join lr x r)
+                else if rh > lh + 2 then
+                  bal (join_aux rl) rx rr
+                else
+                  create l x r
+        in
+          join_aux
+        end
+  
+  (** val remove_min : tree -> elt -> t -> t * elt **)
+  
+  fun remove_min LEAF x r = (r, x)
+    | remove_min (NODE (_, ll, lx, lr)) x r =
+        let
+          val (l', m) = remove_min ll lx lr
+        in
+          (bal l' x r, m)
+        end
+  
+  (** val merge : tree * tree -> tree **)
+  
+  fun merge (LEAF, s2) = s2
+    | merge (s1, LEAF) = s1
+    | merge (s1 as NODE _, NODE (_, l2, x2, r2)) =
+        let
+          val (s2', m) = remove_min l2 x2 r2
+        in
+          bal s1 m s2'
+        end
+  
+  (** val remove : X.t -> tree -> tree **)
+  
+  fun remove x LEAF = LEAF
+    | remove x (NODE (_, l, y, r)) =
+        case X.compare (x, y) of
+          EQUAL => merge (l, r)
+        | LESS => bal (remove x l) y r
+        | GREATER => bal l y (remove x r)
+  
+  (** val concat : tree * tree -> tree **)
+  
+  fun concat (LEAF, s2) = s2
+    | concat (s1, LEAF) = s1
+    | concat (s1, NODE (_, l2, x2, r2)) =
+        let
+          val (s2', m) = remove_min l2 x2 r2
+        in
+          join s1 m s2'
+        end
+
+  (** val split : X.t -> tree -> { left : t, in : bool, right : t } **)
+  
+  fun split x LEAF = { left = LEAF, in_ = false, right = LEAF }
+    | split x (NODE (_, l, y, r)) =
+        case X.compare (x, y) of
+          EQUAL => { left = l, in_ = true, right = r }
+        | LESS =>
+            let val { left = ll, in_ = b, right = rl } = split x l in
+              { left = ll, in_ = b, right = (join rl y r) }
+            end
+        | GREATER =>
+            let val { left = rl, in_ = b, right = rr } = split x r in
+              { left = (join l y rl), in_ = b, right = rr }
+            end
+  
+  (** val inter : tree * tree -> tree **)
+  
+  fun inter (LEAF, s2) = LEAF
+    | inter (s1, LEAF) = LEAF
+    | inter (NODE (_, l1, x1, r1), s2 as NODE _) =
+        let
+          val { left = l2', in_ = pres, right = r2' } = split x1 s2
+        in
+          if pres then
+            join (inter (l1, l2')) x1 (inter (r1, r2'))
+          else
+            concat (inter (l1, l2'), inter (r1, r2'))
+        end
+  
+  (** val diff : tree * tree -> tree **)
+  
+  fun diff (LEAF, s2) = LEAF
+    | diff (s1, LEAF) = s1
+    | diff (NODE (_, l1, x1, r1), s2 as NODE _) =
+        let
+          val { left = l2', in_ = pres, right = r2' } = split x1 s2
+        in
+          if pres then
+            concat (diff (l1, l2'), diff (r1, r2'))
+          else
+            join (diff (l1, l2')) x1 (diff (r1, r2'))
+        end
+  
+  (** val union : tree * tree -> tree **)
+  
+  fun union (LEAF, s2) = s2
+    | union (s1, LEAF) = s1
+    | union (NODE (_, l1, x1, r1), s2 as NODE _) =
+        let
+          val { left = l2', in_ = x, right = r2' } = split x1 s2
+        in
+          join (union (l1, l2')) x1 (union (r1, r2'))
+        end
+  
+  (** val filter : (elt -> bool) -> tree -> tree **)
+  
+  fun filter f LEAF = LEAF
+    | filter f (NODE (_, l, x, r)) =
+        let
+          val l' = filter f l
+          val r' = filter f r
+         in
+           if f x then join l' x r' else concat (l', r')
+         end
+  
+  (** val partition : (elt -> bool) -> t -> t * t **)
+  
+  fun partition f LEAF = (LEAF, LEAF)
+    | partition f (NODE (_, l, x, r)) =
+        let
+          val (l1, l2) = partition f l
+          val (r1, r2) = partition f r
+        in
+          if f x then
+            (join l1 x r1, concat (l2, r2))
+          else
+            (concat (l1, r1), join l2 x r2)
+        end
+end

--- a/test/Main.smi
+++ b/test/Main.smi
@@ -1,4 +1,5 @@
 _require "basis.smi"
 _require "smlunit-lib.smi"
 _require "./ext/StdTest.smi"
+_require "./ext/SetTest.smi"
 _require "./parser/ParserTest.smi"

--- a/test/Main.sml
+++ b/test/Main.sml
@@ -1,5 +1,6 @@
 val suites = SMLUnit.Test.TestList [
   StdTest.suite (),
+  SetTest.suite (),
   ParserTest.suite ()
 ]
 

--- a/test/ext/SetTest.smi
+++ b/test/ext/SetTest.smi
@@ -1,0 +1,7 @@
+_require "basis.smi"
+_require "smlunit-lib.smi"
+_require "ext/Set.smi"
+
+structure SetTest = struct
+  val suite : unit -> SMLUnit.Test.test
+end

--- a/test/ext/SetTest.sml
+++ b/test/ext/SetTest.sml
@@ -1,0 +1,228 @@
+structure SetTest =
+struct
+  open SMLUnit
+  
+  structure OrderedInt =
+  struct
+    type t = int
+    fun compare (n, m) =
+      if n < m then LESS
+      else if n = m then EQUAL
+      else GREATER
+  end
+
+  structure IntSet = Set (OrderedInt)
+
+  val iset_of_list = foldl (fn (n, s) => IntSet.add n s) IntSet.empty
+  fun assertEqualIntSet s1 s2 =
+    Assert.assertTrue
+      (IntSet.equal (s1, s2))
+
+  fun is_empty_empty_test () =
+    Assert.assertTrue (IntSet.is_empty IntSet.empty)
+
+  fun is_empty_singleton_test () =
+    Assert.assertFalse (IntSet.is_empty (IntSet.singleton 42))
+
+  fun mem_true_test () = 
+    Assert.assertTrue
+      (IntSet.mem 810 (iset_of_list [33, ~4, 114, 514, 810]))
+
+  fun mem_false_test () =
+    Assert.assertFalse
+      (IntSet.mem 42 (iset_of_list [33, ~4, 114, 514, 810]))
+
+  fun min_elt_empty_test () =
+    Assert.assertNone
+      (IntSet.min_elt IntSet.empty)
+
+  fun min_elt_not_empty_test () =
+    Assert.assertEqualIntOption
+      (SOME ~4)
+      (IntSet.min_elt (iset_of_list [33, ~4, 114, 514, 810]))
+
+  fun max_elt_empty_test () =
+    Assert.assertNone
+      (IntSet.max_elt IntSet.empty)
+
+  fun max_elt_not_empty_test () =
+    Assert.assertEqualIntOption
+      (SOME 810)
+      (IntSet.max_elt (iset_of_list [33, ~4, 114, 514, 810]))
+
+  fun fold_elements_test () =
+    let 
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+    in
+      Assert.assertEqualList
+        Assert.AssertInt.assertEqualInt
+        (IntSet.elements s)
+        (rev (IntSet.fold op:: s []))
+    end
+
+  fun rev_elements_test () =
+    let 
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+    in
+      Assert.assertEqualList
+        Assert.AssertInt.assertEqualInt
+        (rev (IntSet.elements s))
+        (IntSet.rev_elements s)
+    end
+    
+  fun cardinal_empty_test () =
+    Assert.AssertInt.assertEqualInt
+      0
+      (IntSet.cardinal IntSet.empty)
+
+  fun cardinal_5elements_test () =
+    Assert.AssertInt.assertEqualInt
+      5
+      (IntSet.cardinal (iset_of_list [33, ~4, 114, 514, 810]))
+
+  fun for_all_fold_test () =
+    let
+      fun p n = n mod 2 = 0
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+    in
+      Assert.assertEqualBool
+        (IntSet.for_all p s)
+        (IntSet.fold (fn (n, b) => p n andalso b) s true)
+    end
+
+  fun exists_fold_test () =
+    let
+      fun p n = n mod 2 = 1
+      val s = iset_of_list [114, 514, 810]
+    in
+      Assert.assertEqualBool
+        (IntSet.exists p s)
+        (IntSet.fold (fn (n, b) => p n orelse b) s false)
+    end
+
+  fun equal_test () =
+    Assert.assertTrue
+      (IntSet.equal
+        (iset_of_list [3, 1, 4], iset_of_list [1, 4, 3]))
+
+  fun subset_test () =
+    Assert.assertTrue
+      (IntSet.subset
+        (iset_of_list [2, 7], iset_of_list [2, 7, 1, 8]))
+
+  fun remove_test () =
+    assertEqualIntSet
+      (IntSet.remove 1
+        (IntSet.remove 4
+          (iset_of_list [3, 1, 4])))
+      (IntSet.singleton 3)
+
+  fun split_mem_found_test () =
+    let 
+      val n = 810
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+    in
+      Assert.assertEqualBool
+        (IntSet.mem n s)
+        (#in_ (IntSet.split n s))
+    end
+
+  fun split_mem_not_found_test () =
+    let 
+      val n = 42
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+    in
+      Assert.assertEqualBool
+        (IntSet.mem n s)
+        (#in_ (IntSet.split n s))
+    end
+
+  fun split_filter_left_test () =
+    let
+      val n = 810
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+      fun p m = m < n
+    in
+      assertEqualIntSet
+        (IntSet.filter p s)
+        (#left (IntSet.split n s))
+    end
+
+  fun split_filter_right_test () =
+    let
+      val n = 810
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+      fun p m = m > n
+    in
+      assertEqualIntSet
+        (IntSet.filter p s)
+        (#right (IntSet.split n s))
+    end
+
+  fun inter_test () =
+    assertEqualIntSet
+      (IntSet.inter
+        (iset_of_list [3, 1, 4], iset_of_list [2, 7, 1]))
+      (iset_of_list [1])
+
+  fun diff_test () =
+    assertEqualIntSet
+      (IntSet.diff
+        (iset_of_list [3, 1, 4, 1, 5, 9, 2], iset_of_list [2, 7, 1]))
+      (iset_of_list [3, 4, 5, 9])
+
+  fun union_test () =
+    assertEqualIntSet
+      (IntSet.union
+        (iset_of_list [3, 1, 4], iset_of_list [2, 7, 1]))
+      (iset_of_list [3, 1, 4, 2, 7])
+
+  fun partition_left_test () =
+    let
+      fun p n = n mod 2 = 0
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+    in
+      assertEqualIntSet
+        (IntSet.filter p s)
+        (#1 (IntSet.partition p s))
+    end
+  
+  fun partition_right_test () =
+    let
+      fun p n = n mod 2 = 0
+      val s = iset_of_list [33, ~4, 114, 514, 810]
+    in
+      assertEqualIntSet
+        (IntSet.filter (not o p) s)
+        (#2 (IntSet.partition p s))
+    end
+
+  fun suite () = Test.labelTests [
+    ("is_empty empty test", is_empty_empty_test),
+    ("is_empty singleton test", is_empty_singleton_test),
+    ("mem found test", mem_true_test),
+    ("mem not found test", mem_false_test),
+    ("min_elt empty test", min_elt_empty_test),
+    ("min_elt not empty test", min_elt_not_empty_test),
+    ("max_elt empty test", max_elt_empty_test),
+    ("max_elt not_empty test", max_elt_not_empty_test),
+    ("fold elements test", fold_elements_test),
+    ("rev_elements test", rev_elements_test),
+    ("cardinal empty test", cardinal_empty_test),
+    ("cardinal 5 elements test", cardinal_5elements_test),
+    ("for_all fold test", for_all_fold_test),
+    ("exists fold test", exists_fold_test),
+    ("equal test", equal_test),
+    ("subset test", subset_test),
+    ("remove test", remove_test),
+    ("split mem found test", split_mem_found_test),
+    ("split mem not found test", split_mem_not_found_test),
+    ("split filter left test", split_filter_left_test),
+    ("split filter right test", split_filter_right_test),
+    ("inter test", inter_test),
+    ("diff test", diff_test),
+    ("union test", union_test),
+    ("partition left test", partition_left_test),
+    ("partition right test", partition_right_test)
+  ]
+end

--- a/test/ext/SetTest.sml
+++ b/test/ext/SetTest.sml
@@ -13,46 +13,46 @@ struct
 
   structure IntSet = Set (OrderedInt)
 
-  val iset_of_list = foldl (fn (n, s) => IntSet.add n s) IntSet.empty
+  val isetFromList = foldl (fn (n, s) => IntSet.add n s) IntSet.empty
   fun assertEqualIntSet s1 s2 =
     Assert.assertTrue
       (IntSet.equal (s1, s2))
 
-  fun is_empty_empty_test () =
-    Assert.assertTrue (IntSet.is_empty IntSet.empty)
+  fun isEmptyEmptyTest () =
+    Assert.assertTrue (IntSet.isEmpty IntSet.empty)
 
-  fun is_empty_singleton_test () =
-    Assert.assertFalse (IntSet.is_empty (IntSet.singleton 42))
+  fun isEmptySingletonTest () =
+    Assert.assertFalse (IntSet.isEmpty (IntSet.singleton 42))
 
-  fun mem_true_test () = 
+  fun mem_trueTest () = 
     Assert.assertTrue
-      (IntSet.mem 810 (iset_of_list [33, ~4, 114, 514, 810]))
+      (IntSet.mem 810 (isetFromList [33, ~4, 114, 514, 810]))
 
-  fun mem_false_test () =
+  fun mem_falseTest () =
     Assert.assertFalse
-      (IntSet.mem 42 (iset_of_list [33, ~4, 114, 514, 810]))
+      (IntSet.mem 42 (isetFromList [33, ~4, 114, 514, 810]))
 
-  fun min_elt_empty_test () =
+  fun minEltEmptyTest () =
     Assert.assertNone
-      (IntSet.min_elt IntSet.empty)
+      (IntSet.minElt IntSet.empty)
 
-  fun min_elt_not_empty_test () =
+  fun minEltNotEmptyTest () =
     Assert.assertEqualIntOption
       (SOME ~4)
-      (IntSet.min_elt (iset_of_list [33, ~4, 114, 514, 810]))
+      (IntSet.minElt (isetFromList [33, ~4, 114, 514, 810]))
 
-  fun max_elt_empty_test () =
+  fun maxEltEmptyTest () =
     Assert.assertNone
-      (IntSet.max_elt IntSet.empty)
+      (IntSet.maxElt IntSet.empty)
 
-  fun max_elt_not_empty_test () =
+  fun maxEltNotEmptyTest () =
     Assert.assertEqualIntOption
       (SOME 810)
-      (IntSet.max_elt (iset_of_list [33, ~4, 114, 514, 810]))
+      (IntSet.maxElt (isetFromList [33, ~4, 114, 514, 810]))
 
-  fun fold_elements_test () =
+  fun foldElementsTest () =
     let 
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
     in
       Assert.assertEqualList
         Assert.AssertInt.assertEqualInt
@@ -60,169 +60,169 @@ struct
         (rev (IntSet.fold op:: s []))
     end
 
-  fun rev_elements_test () =
+  fun revElementsTest () =
     let 
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
     in
       Assert.assertEqualList
         Assert.AssertInt.assertEqualInt
         (rev (IntSet.elements s))
-        (IntSet.rev_elements s)
+        (IntSet.revElements s)
     end
     
-  fun cardinal_empty_test () =
+  fun cardinalEmptyTest () =
     Assert.AssertInt.assertEqualInt
       0
       (IntSet.cardinal IntSet.empty)
 
-  fun cardinal_5elements_test () =
+  fun cardinal5ElementsTest () =
     Assert.AssertInt.assertEqualInt
       5
-      (IntSet.cardinal (iset_of_list [33, ~4, 114, 514, 810]))
+      (IntSet.cardinal (isetFromList [33, ~4, 114, 514, 810]))
 
-  fun for_all_fold_test () =
+  fun forallFoldTest () =
     let
       fun p n = n mod 2 = 0
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
     in
       Assert.assertEqualBool
-        (IntSet.for_all p s)
+        (IntSet.forall p s)
         (IntSet.fold (fn (n, b) => p n andalso b) s true)
     end
 
-  fun exists_fold_test () =
+  fun existsFoldTest () =
     let
       fun p n = n mod 2 = 1
-      val s = iset_of_list [114, 514, 810]
+      val s = isetFromList [114, 514, 810]
     in
       Assert.assertEqualBool
         (IntSet.exists p s)
         (IntSet.fold (fn (n, b) => p n orelse b) s false)
     end
 
-  fun equal_test () =
+  fun equalTest () =
     Assert.assertTrue
       (IntSet.equal
-        (iset_of_list [3, 1, 4], iset_of_list [1, 4, 3]))
+        (isetFromList [3, 1, 4], isetFromList [1, 4, 3]))
 
-  fun subset_test () =
+  fun subsetTest () =
     Assert.assertTrue
       (IntSet.subset
-        (iset_of_list [2, 7], iset_of_list [2, 7, 1, 8]))
+        (isetFromList [2, 7], isetFromList [2, 7, 1, 8]))
 
-  fun remove_test () =
+  fun removeTest () =
     assertEqualIntSet
       (IntSet.remove 1
         (IntSet.remove 4
-          (iset_of_list [3, 1, 4])))
+          (isetFromList [3, 1, 4])))
       (IntSet.singleton 3)
 
-  fun split_mem_found_test () =
+  fun splitMemFoundTest () =
     let 
       val n = 810
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
     in
       Assert.assertEqualBool
         (IntSet.mem n s)
-        (#in_ (IntSet.split n s))
+        (#present (IntSet.split n s))
     end
 
-  fun split_mem_not_found_test () =
+  fun splitMemNotFoundTest () =
     let 
       val n = 42
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
     in
       Assert.assertEqualBool
         (IntSet.mem n s)
-        (#in_ (IntSet.split n s))
+        (#present (IntSet.split n s))
     end
 
-  fun split_filter_left_test () =
+  fun splitFilterLessTest () =
     let
       val n = 810
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
       fun p m = m < n
     in
       assertEqualIntSet
         (IntSet.filter p s)
-        (#left (IntSet.split n s))
+        (#less (IntSet.split n s))
     end
 
-  fun split_filter_right_test () =
+  fun splitFilterGreaterTest () =
     let
       val n = 810
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
       fun p m = m > n
     in
       assertEqualIntSet
         (IntSet.filter p s)
-        (#right (IntSet.split n s))
+        (#greater (IntSet.split n s))
     end
 
-  fun inter_test () =
+  fun interTest () =
     assertEqualIntSet
       (IntSet.inter
-        (iset_of_list [3, 1, 4], iset_of_list [2, 7, 1]))
-      (iset_of_list [1])
+        (isetFromList [3, 1, 4], isetFromList [2, 7, 1]))
+      (isetFromList [1])
 
-  fun diff_test () =
+  fun diffTest () =
     assertEqualIntSet
       (IntSet.diff
-        (iset_of_list [3, 1, 4, 1, 5, 9, 2], iset_of_list [2, 7, 1]))
-      (iset_of_list [3, 4, 5, 9])
+        (isetFromList [3, 1, 4, 1, 5, 9, 2], isetFromList [2, 7, 1]))
+      (isetFromList [3, 4, 5, 9])
 
-  fun union_test () =
+  fun unionTest () =
     assertEqualIntSet
       (IntSet.union
-        (iset_of_list [3, 1, 4], iset_of_list [2, 7, 1]))
-      (iset_of_list [3, 1, 4, 2, 7])
+        (isetFromList [3, 1, 4], isetFromList [2, 7, 1]))
+      (isetFromList [3, 1, 4, 2, 7])
 
-  fun partition_left_test () =
+  fun partitionSatisfyTest () =
     let
       fun p n = n mod 2 = 0
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
     in
       assertEqualIntSet
         (IntSet.filter p s)
-        (#1 (IntSet.partition p s))
+        (#satisfy (IntSet.partition p s))
     end
   
-  fun partition_right_test () =
+  fun partitionDissatisfyTest () =
     let
       fun p n = n mod 2 = 0
-      val s = iset_of_list [33, ~4, 114, 514, 810]
+      val s = isetFromList [33, ~4, 114, 514, 810]
     in
       assertEqualIntSet
         (IntSet.filter (not o p) s)
-        (#2 (IntSet.partition p s))
+        (#dissatisfy (IntSet.partition p s))
     end
 
   fun suite () = Test.labelTests [
-    ("is_empty empty test", is_empty_empty_test),
-    ("is_empty singleton test", is_empty_singleton_test),
-    ("mem found test", mem_true_test),
-    ("mem not found test", mem_false_test),
-    ("min_elt empty test", min_elt_empty_test),
-    ("min_elt not empty test", min_elt_not_empty_test),
-    ("max_elt empty test", max_elt_empty_test),
-    ("max_elt not_empty test", max_elt_not_empty_test),
-    ("fold elements test", fold_elements_test),
-    ("rev_elements test", rev_elements_test),
-    ("cardinal empty test", cardinal_empty_test),
-    ("cardinal 5 elements test", cardinal_5elements_test),
-    ("for_all fold test", for_all_fold_test),
-    ("exists fold test", exists_fold_test),
-    ("equal test", equal_test),
-    ("subset test", subset_test),
-    ("remove test", remove_test),
-    ("split mem found test", split_mem_found_test),
-    ("split mem not found test", split_mem_not_found_test),
-    ("split filter left test", split_filter_left_test),
-    ("split filter right test", split_filter_right_test),
-    ("inter test", inter_test),
-    ("diff test", diff_test),
-    ("union test", union_test),
-    ("partition left test", partition_left_test),
-    ("partition right test", partition_right_test)
+    ("isEmpty empty test", isEmptyEmptyTest),
+    ("isEmpty singleton test", isEmptySingletonTest),
+    ("mem found test", mem_trueTest),
+    ("mem not found test", mem_falseTest),
+    ("minElt empty test", minEltEmptyTest),
+    ("minElt not empty test", minEltNotEmptyTest),
+    ("maxElt empty test", maxEltEmptyTest),
+    ("maxElt not empty test", maxEltNotEmptyTest),
+    ("fold elements test", foldElementsTest),
+    ("revElements test", revElementsTest),
+    ("cardinal empty test", cardinalEmptyTest),
+    ("cardinal 5 elements test", cardinal5ElementsTest),
+    ("forall fold test", forallFoldTest),
+    ("exists fold test", existsFoldTest),
+    ("equal test", equalTest),
+    ("subset test", subsetTest),
+    ("remove test", removeTest),
+    ("split mem found test", splitMemFoundTest),
+    ("split mem not found test", splitMemNotFoundTest),
+    ("split filter less test", splitFilterLessTest),
+    ("split filter greater test", splitFilterGreaterTest),
+    ("inter test", interTest),
+    ("diff test", diffTest),
+    ("union test", unionTest),
+    ("partition left test", partitionSatisfyTest),
+    ("partition right test", partitionDissatisfyTest)
   ]
 end


### PR DESCRIPTION
CoqのFSetAVL.Makeを変換して、得られたSMLのコードに修正を加えてSetの実装を得ました。
実装、インターフェース共にOCamlのSetとほぼ同等ですが、SMLに適するよう意図的にカリー化をしないようにした部分があります。
