### PR TITLE
文字列化関数を実装する。

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ SMLSHARP = smlsharp
 SMLSHARP_FLAGS = -I lib
 SMLSHARP_CFLAGS = -O2
 SMLSHARP_LDFLAGS =
-CFLAGS += -m32
+CFLAGS += -m32 -Iinclude
 
 # ------------------------------------------------------------
 #  prepare variables

--- a/example/hello.sml
+++ b/example/hello.sml
@@ -1,8 +1,7 @@
-type t = { x : int, y : int }
-datatype s = Foo | Bar
+datatype 'a s = Foo of 'a | Bar
 
 val () =
   Std.dump 42;
   Std.dump "foo";
   Std.dump { x = 10, y = 42 };
-  Std.dump Foo
+  Std.dump (Foo { x = true })

--- a/example/hello.sml
+++ b/example/hello.sml
@@ -1,2 +1,8 @@
+type t = { x : int, y : int }
+datatype s = Foo | Bar
+
 val () =
-  print "hello, world\n"
+  Std.dump 42;
+  Std.dump "foo";
+  Std.dump { x = 10, y = 42 };
+  Std.dump Foo

--- a/include/intinf.h
+++ b/include/intinf.h
@@ -1,0 +1,45 @@
+/**
+ * intinf.h
+ * @copyright (c) 2007, Tohoku University.
+ * @author UENO Katsuhiro
+ */
+#ifndef SMLSHARP__INTINF_H__
+#define SMLSHARP__INTINF_H__
+
+#include <gmp.h>
+
+struct sml_intinf {
+	mpz_t value;
+};
+
+#define sml_intinf_init(v)       mpz_init((v)->value)
+#define sml_intinf_clear(v)      mpz_clear((v)->value)
+#define sml_intinf_set(v,s)      mpz_set((v)->value, (s)->value)
+#define sml_intinf_set_str(v,s,b) mpz_set_str((v)->value, (s), (b))
+#define sml_intinf_set_si(v,n)   mpz_set_si((v)->value, (n))
+#define sml_intinf_set_ui(v,n)   mpz_set_ui((v)->value, (n))
+#define sml_intinf_set_d(v,n)    mpz_set_d((v)->value, (n))
+#define sml_intinf_size(v,b)     mpz_sizeinbase((v)->value, (b))
+#define sml_intinf_fmt(v,b)      mpz_get_str(NULL, (b), (v)->value)
+#define sml_intinf_get_si(v)     mpz_get_si((v)->value)
+#define sml_intinf_get_ui(v)     mpz_get_ui((v)->value)
+#define sml_intinf_get_d(v)      mpz_get_d((v)->value)
+#define sml_intinf_abs(z,x)      mpz_abs((z)->value, (x)->value)
+#define sml_intinf_add(z,x,y)    mpz_add((z)->value, (x)->value, (y)->value)
+#define sml_intinf_sub(z,x,y)    mpz_sub((z)->value, (x)->value, (y)->value)
+#define sml_intinf_neg(z,x)      mpz_neg((z)->value, (x)->value)
+#define sml_intinf_mul(z,x,y)    mpz_mul((z)->value, (x)->value, (y)->value)
+#define sml_intinf_div(z,x,y)    mpz_fdiv_q((z)->value, (x)->value, (y)->value)
+#define sml_intinf_mod(z,x,y)    mpz_fdiv_r((z)->value, (x)->value, (y)->value)
+#define sml_intinf_quot(z,x,y)   mpz_tdiv_q((z)->value, (x)->value, (y)->value)
+#define sml_intinf_rem(z,x,y)    mpz_tdiv_r((z)->value, (x)->value, (y)->value)
+#define sml_intinf_ior(z,x,y)    mpz_ior((z)->value, (x)->value, (y)->value)
+#define sml_intinf_xor(z,x,y)    mpz_xor((z)->value, (x)->value, (y)->value)
+#define sml_intinf_and(z,x,y)    mpz_and((z)->value, (x)->value, (y)->value)
+#define sml_intinf_com(z,x)      mpz_com((z)->value, (x)->value)
+#define sml_intinf_pow(z,x,y)    mpz_pow_ui((z)->value, (x)->value, (y))
+#define sml_intinf_log2(z)       (mpz_sizeinbase((z)->value, 2) - 1)
+#define sml_intinf_cmp(x,y)      mpz_cmp((x)->value, (y)->value)
+#define sml_intinf_sign(x)       mpz_sgn((x)->value)
+
+#endif /* SMLSHARP__INTINF_H__ */

--- a/include/object.h
+++ b/include/object.h
@@ -1,0 +1,124 @@
+/*
+ * object.h - SML# heap object format
+ * @copyright (c) 2007, Tohoku University.
+ * @author UENO Katsuhiro
+ */
+#ifndef SMLSHARP__OBJECT_H__
+#define SMLSHARP__OBJECT_H__
+
+#include <limits.h>
+
+/*
+ * size of a bitmap word in heap objects and stack frames.
+ */
+#define SIZEOF_BITMAP     sizeof(unsigned int)
+#define BITMAP_NUM_BITS   (SIZEOF_BITMAP * CHAR_BIT)
+
+#define BITMAP_BIT(bitmaps, index) \
+	(((bitmaps)[(index) / BITMAP_NUM_BITS] >> ((index) % BITMAP_NUM_BITS)) \
+	 & 0x1)
+
+#define TAG_UNBOXED  0
+#define TAG_BOXED    1
+
+#define BITMAP_WORD(offset) \
+	((unsigned int)(1U << ((offset) / sizeof(void*))))
+
+/*
+ * Object format:
+ *
+ *  +------+-----------------------------------+---------------+
+ *  |header|            payload                |     bitmap    |
+ *--+------+-----------------------------------+---------------+--> addr
+ *         ^
+ *         |
+ *       objptr
+ *
+ * header (unsigned int) :
+ *   Header of the object. See below.
+ * objptr (void*) :
+ *   The pointer indicating the object.
+ *   This pointer is always aligned for arbitrary type.
+ * payload :
+ *   Payload data of the object.
+ *   Payload may be either
+ *   - arbitrary data,
+ *   - array of heap object pointers,
+ *   - arbitrary data with bitmap, or
+ *   - intinf.
+ * bitmap (unsigned int[]) :
+ *   bitmap indicating the position of pointers in payload.
+ *   (exists only if header.type == OBJTYPE_RECORD)
+ *
+ * Heap object header:
+ *
+ * Heap object header is an "unsigned int" value placed at
+ * (objptr - sizeof(unsigned int)).
+ * we assume that sizeof(unsigned int) >= 4.
+ *
+ *  MSB                                           LSB
+ *  +--------+------+-------------------------------+
+ *  |  type  |  gc  |           size                |
+ *  +--------+------+-------------------------------+
+ *   31    28 27  26 25                            0
+ *
+ *                          equality        pointer_detection
+ * OBJTYPE_UNBOXED_VECTOR   obj_equal       no pointer
+ * OBJTYPE_BOXED_VECTOR     obj_equal       pointer array
+ * OBJTYPE_UNBOXED_ARRAY    pointer_equal   no pointer
+ * OBJTYPE_BOXED_ARRAY      pointer_equal   pointer array
+ * OBJTYPE_RECORD           obj_equal       bitmap
+ * OBJTYPE_INTINF           intinf_equal    no pointer
+ *
+ * gc: Flags for garbage collector.
+ *     Allocator must be set 0 to these bits.
+ *
+ * size: The size of payload part of the object.
+ */
+
+#define OBJ_HEADER_SIZE  sizeof(unsigned int)
+
+#define OBJ_TYPE_MASK    (~0U << 28)
+#define OBJ_GC1_MASK     (1U << 26)
+#define OBJ_GC2_MASK     (1U << 27)
+#define OBJ_SIZE_MASK    (~(OBJ_TYPE_MASK | OBJ_GC1_MASK | OBJ_GC2_MASK))
+
+#define OBJTYPE_UNBOXED         (0U << 28)
+#define OBJTYPE_BOXED           (1U << 28)
+#define OBJTYPE_VECTOR          (0x0U << 29)
+#define OBJTYPE_ARRAY           (0x1U << 29)
+
+#define OBJTYPE_UNBOXED_VECTOR  (OBJTYPE_VECTOR | OBJTYPE_UNBOXED)
+#define OBJTYPE_BOXED_VECTOR    (OBJTYPE_VECTOR | OBJTYPE_BOXED)
+#define OBJTYPE_UNBOXED_ARRAY   (OBJTYPE_ARRAY | OBJTYPE_UNBOXED)
+#define OBJTYPE_BOXED_ARRAY     (OBJTYPE_ARRAY | OBJTYPE_BOXED)
+#define OBJTYPE_RECORD          ((0x2U << 29) | OBJTYPE_BOXED)
+#define OBJTYPE_INTINF          ((0x3U << 29) | OBJTYPE_UNBOXED)
+
+#define OBJ_DUMMY_HEADER   0  /* valid header for dummy object */
+
+#define OBJ_HEADER_WORD(objtype, size) \
+	((unsigned int)(objtype) | (unsigned int)(size))
+
+#define OBJ_HEADER(obj)  (*(unsigned int*)((char*)(obj) - sizeof(unsigned int)))
+#define OBJ_TYPE(obj)    (OBJ_HEADER(obj) & OBJ_TYPE_MASK)
+#define OBJ_SIZE(obj)    (OBJ_HEADER(obj) & OBJ_SIZE_MASK)
+#define OBJ_GC1(obj)     (OBJ_HEADER(obj) & OBJ_GC1_MASK)
+#define OBJ_GC2(obj)     (OBJ_HEADER(obj) & OBJ_GC2_MASK)
+#define OBJ_BITMAP(obj)  ((unsigned int*)((char*)(obj) + OBJ_SIZE(obj)))
+
+/* note that object has bitmap only when OBJ_TYPE == OBJTYPE_RECORD. */
+#define OBJ_BITMAPS_LEN(payload_size) \
+	(((payload_size) / sizeof(void*) + BITMAP_NUM_BITS - 1) \
+	 / BITMAP_NUM_BITS)
+#define OBJ_NUM_BITMAPS(obj) OBJ_BITMAPS_LEN(OBJ_SIZE(obj))
+
+#define OBJ_TOTAL_SIZE(obj) \
+	(OBJ_HEADER_SIZE + \
+	 OBJ_SIZE(obj) + (OBJ_TYPE(obj) == OBJTYPE_RECORD \
+			  ? OBJ_NUM_BITMAPS(obj) * SIZEOF_BITMAP : 0))
+
+/* payload of string object includes a sentinel ('\0') */
+#define OBJ_STR_SIZE(obj)  ((size_t)(OBJ_SIZE(obj) - 1))
+
+#endif /* SMLSHARP__OBJECT_H__ */

--- a/include/smlsharp.h
+++ b/include/smlsharp.h
@@ -1,0 +1,388 @@
+/**
+ * smlsharp.h - SML# runtime implemenatation
+ * @copyright (c) 2007-2009, Tohoku University.
+ * @author UENO Katsuhiro
+ * @version $Id: $
+ */
+#ifndef SMLSHARP__SMLSHARP_H__
+#define SMLSHARP__SMLSHARP_H__
+
+#include <stddef.h>
+
+/* FILELINE : "<filename>:<lineno>(<function>)" for debug */
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#define __func__ __func__
+#elif defined __GNUC__ && __GNUC__ >= 2
+#define __func__ __extension__ __FUNCTION__
+#else
+#define __func__ "(unknown)"
+#endif
+#define FILELINE__(x,y) x":"#y
+#define FILELINE_(x,y) FILELINE__(x,y)
+#define FILELINE FILELINE_(__FILE__, __LINE__)
+
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#define restrict restrict
+#elif defined __GNUC__ && __GNUC__ >= 3
+#define restrict __restrict__
+#else
+#define restrict
+#endif
+
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#define inline inline
+#elif defined __GNUC__ && __GNUC__ >= 2
+#define inline __inline__
+#else
+#define inline
+#endif
+
+#if defined __GNUC__ && __GNUC__ >= 2
+#define NOINLINE __attribute__((noinline))
+#else
+#define NOINLINE
+#endif
+
+/* GNU C extensions */
+
+#ifndef GCC_VERSION
+#ifdef __GNUC__
+#define GCC_VERSION (__GNUC__ * 1000 + __GNUC_MINOR__)
+#endif
+#endif /* GCC_VERSION */
+
+#if defined(__GNUC__) && GCC_VERSION >= 2096
+#define ATTR_MALLOC __attribute__((malloc))
+#else
+#define ATTR_MALLOC
+#endif
+
+#if defined(__GNUC__) && GCC_VERSION >= 3000
+#define ATTR_PURE __attribute__((pure))
+#else
+#define ATTR_PURE
+#endif
+
+#if defined(__GNUC__) && GCC_VERSION >= 3003
+#define ATTR_NONNULL(n) __attribute__((nonnull(n)))
+#else
+#define ATTR_NONNULL(n)
+#endif
+
+#if defined(__GNUC__)
+#define ATTR_PRINTF(m,n) __attribute__((format(printf,m,n))) ATTR_NONNULL(m)
+#endif
+
+#if defined(__GNUC__)
+#define ATTR_NORETURN __attribute__((noreturn))
+#endif
+
+#if defined(__GNUC__)
+#define ATTR_UNUSED __attribute__((unused))
+#endif
+
+#if defined(__GNUC__)
+/* Boland fastcall; %eax, %edx, %ecx */
+#define SML_PRIMITIVE __attribute__((regparm(3))) NOINLINE
+#else
+/* Microsoft fastcall; %ecx, %edx */
+/* #define SML_PRIMITIVE __attribute__((fastcall)) */
+#define SML_PRIMITIVE NOINLINE
+#endif
+
+/* the number of elements of an array. */
+#define arraysize(a)   (sizeof(a) / sizeof(a[0]))
+
+/* ALIGNSIZE(x,y) : round up x to the multiple of y. */
+#define ALIGNSIZE(x,y)  (((x) + (y) - 1) - ((x) + (y) - 1) % (y))
+
+/* the most conservative memory alignment.
+ * It should be differed for each architecture. */
+#ifndef MAXALIGN
+union sml__alignment__ {
+	char c; short s; int i; long n;
+	float f; double d; long double x; void *p;
+};
+#define MAXALIGN    (sizeof(union sml__alignment__))
+#endif
+
+/*
+ * print fatal error message and abort the program.
+ * err : error status describing why this error happened.
+ *       (0: no error status, positive: system errno, negative: runtime error)
+ * format, ... : standard output format (same as printf)
+ */
+void sml_fatal(int err, const char *format, ...)
+     ATTR_PRINTF(2, 3) ATTR_NORETURN;
+
+/*
+ * print error message.
+ */
+void sml_error(int err, const char *format, ...) ATTR_PRINTF(2, 3);
+
+/*
+ * print warning message.
+ */
+void sml_warn(int err, const char *format, ...) ATTR_PRINTF(2, 3);
+
+/*
+ * print fatal error message with system error status and abort the program.
+ */
+void sml_sysfatal(const char *format, ...) ATTR_PRINTF(1, 2) ATTR_NORETURN;
+
+/*
+ * print error message with system error status.
+ */
+void sml_syserror(const char *format, ...) ATTR_PRINTF(1, 2);
+
+/*
+ * print warning message with system error status.
+ */
+void sml_syswarn(const char *format, ...) ATTR_PRINTF(1, 2);
+
+/*
+ * print notice message.
+ */
+void sml_notice(const char *format, ...) ATTR_PRINTF(1, 2);
+
+/*
+ * print debug message.
+ */
+void sml_debug(const char *format, ...) ATTR_PRINTF(1, 2);
+
+/*
+ * DBG((format, ...));
+ * print debug message.
+ *
+ * ASSERT(cond);
+ * abort the program if cond is not satisfied.
+ *
+ * FATAL((err, format, ...));
+ * print fatal error message with position and abort the program.
+ *
+ * DBG and ASSERT are enabled only if the program is compiled in debug mode.
+ */
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#define DEBUG__(fmt, ...) \
+	sml_debug("%s:%d:%s: "fmt"\n", __FILE__,__LINE__,__func__,##__VA_ARGS__)
+#define DEBUG_(args) DEBUG__ args
+#define FATAL__(err, fmt, ...) \
+	sml_fatal(err, "%s:%d:%s: "fmt, __FILE__,__LINE__,__func__,##__VA_ARGS__)
+#define FATAL(args) FATAL__ args
+#elif defined __GNUC__
+#define DEBUG__(fmt, args...) \
+	sml_debug("%s:%d:%s: "fmt"\n", __FILE__,__LINE__,__func__,##args)
+#define DEBUG_(args) DEBUG__ args
+#define FATAL__(err, fmt, args...) \
+	sml_fatal(err, "%s:%d:%s: "fmt, __FILE__,__LINE__,__func__,##args)
+#define FATAL(args) FATAL__ args
+#else
+#define DEBUG_(args) \
+	((void)sml_debug("%s:%d: ", __FILE__,__LINE__), \
+	 (void)sml_debug args, \
+	 (void)sml_debug("\n"))
+#define FATAL(args) (sml_fatal args)
+#endif
+
+#ifdef DEBUG
+#define DBG(args) DEBUG_(args)
+#else
+#define DBG(args)
+#endif /* DEBUG */
+
+#if defined DEBUG || defined ENABLE_ASSERT
+#define ASSERT(expr) \
+	((expr) ? (void)0 : (void)FATAL((0, "assertion failed: %s", #expr)))
+#else
+#define ASSERT(expr) ((void)0)
+#endif /* ENABLE_ASSERT */
+
+/*
+ * for internal use.
+ */
+enum sml_msg_level {
+	MSG_FATAL,
+	MSG_ERROR,
+	MSG_WARN,
+	MSG_NOTICE,
+	MSG_DEBUG
+};
+void sml_set_verbose(enum sml_msg_level level);
+#if 0
+void sml_msg_set_hook(FILE *(*start_hook)(enum sml_msg_level level),
+		      void (*end_hook)(FILE *f, enum sml_msg_level level));
+#endif
+
+/*
+ * safe malloc and realloc.
+ */
+void *xmalloc(size_t size) ATTR_MALLOC;
+void *xrealloc(void *p, size_t size) ATTR_MALLOC;
+
+#if 0
+void xfree(void *);
+#define free xfree
+#ifdef DEBUG
+void *sml_xmem_debug(void *p, const char *prefix, const char *pos);
+#define xmalloc(x) xmem_debug(xmalloc(x), "xmalloc", FILELINE)
+#define xrealloc(x) xmem_debug(xrealloc(x), "xrealloc", FILELINE)
+#define free(x) xmem_debug(x, "free", FILELINE)
+#endif
+#endif
+
+/*
+ * naive obstack implementation.
+ * Note that this implementation doesn't take care of object alignemnt.
+ */
+typedef struct sml_obstack sml_obstack_t;
+void sml_obstack_blank(sml_obstack_t **obstack, size_t size);
+void *sml_obstack_finish(sml_obstack_t *obstack);
+void *sml_obstack_base(sml_obstack_t *obstack);
+void *sml_obstack_next_free(sml_obstack_t *obstack);
+size_t sml_obstack_object_size(sml_obstack_t *obstack);
+void *sml_obstack_alloc(sml_obstack_t **obstack, size_t size);
+void sml_obstack_free(sml_obstack_t **obstack, void *ptr);
+
+void sml_obstack_align(sml_obstack_t **obstack, size_t size);
+
+/* use obstack growing object as extensible array */
+void *sml_obstack_extend(sml_obstack_t **obstack, size_t size);
+void sml_obstack_shrink(sml_obstack_t **obstack, void *p);
+
+/* enumerate chunks in obstack */
+void sml_obstack_enum_chunk(sml_obstack_t *obstack,
+			    void (*f)(void *start, void *end, void *data),
+			    void *data);
+int sml_obstack_is_empty(sml_obstack_t *obstack);
+
+/*
+ * stack frame address
+ * FIXME: platform dependent
+ */
+#define CALLER_FRAME_END_ADDRESS() \
+	((void**)__builtin_frame_address(0) + 2)
+#define FRAME_CODE_ADDRESS(frame_end) \
+	(*((void**)(frame_end) - 1))
+#define NEXT_FRAME(frame_begin) \
+	((void**)frame_begin + 1)
+
+/*
+ * gc root management
+ */
+
+/*
+ * rootset enumeration mode.
+ * - MAJOR means enumerating all.
+ * - MINOR means enumerating only new ones.
+ */
+enum sml_gc_mode {
+	MINOR,
+	MAJOR
+#ifdef DEBUG
+	,TRY_MAJOR  /* same as MAJOR but dry run */
+#endif /* DEBUG */
+};
+
+void sml_register_stackmap(void *map_begin, void *code_begin);
+int sml_gc_initiate(void (*trace)(void **), enum sml_gc_mode mode, void *data);
+void sml_gc_done(void);
+
+/*
+ * thread control context
+ */
+SML_PRIMITIVE void sml_control_start(void);
+SML_PRIMITIVE void sml_control_finish(void);
+SML_PRIMITIVE void sml_control_suspend(void);
+SML_PRIMITIVE void sml_control_resume(void);
+
+SML_PRIMITIVE void sml_check_gc(void);
+volatile unsigned int sml_check_gc_flag;
+
+void *sml_current_thread_heap(void);
+void *sml_current_thread_exn(void);
+
+void sml_save_fp(void *frame_pointer);
+
+SML_PRIMITIVE void sml_push_fp(void);
+SML_PRIMITIVE void sml_pop_fp(void);
+int sml_alloc_available(void);
+void **sml_tmp_root(void);
+
+void sml_control_init(void);
+void sml_control_free(void);
+
+unsigned int sml_num_threads(void);
+
+
+#ifdef CONCURRENT
+enum sml_sync_phase { ASYNC, SYNC1, SYNC2, MARK };
+enum sml_sync_phase sml_current_phase(void);
+#endif /* CONCURRENT */
+
+
+/*
+ * SML# heap object management
+ */
+SML_PRIMITIVE void *sml_alloc(unsigned int objsize);
+SML_PRIMITIVE void *sml_load_intinf(const char *hexsrc);
+SML_PRIMITIVE void **sml_find_callback(void *codeaddr, void *env);
+SML_PRIMITIVE void *sml_alloc_code(void);
+
+SML_PRIMITIVE void *sml_obj_dup(void *obj);
+SML_PRIMITIVE int sml_obj_equal(void *obj1, void *obj2);
+SML_PRIMITIVE void sml_write(void *objaddr, void **writeaddr, void *new_value);
+void sml_copyary(void **src, unsigned int si, void **dst, unsigned int di,
+		 unsigned int len);
+
+struct sml_intinf;
+typedef struct sml_intinf sml_intinf_t;
+
+void sml_obj_enum_ptr(void *obj, void (*callback)(void **));
+void *sml_obj_alloc(unsigned int objtype, size_t payload_size);
+void *sml_record_alloc(size_t payload_size);
+char *sml_str_alloc(size_t len);
+NOINLINE char *sml_str_new(const char *str);
+char *sml_str_new2(const char *str, size_t len);
+sml_intinf_t *sml_intinf_new(void);
+void *sml_intinf_hex(void *obj);
+
+/*
+ * exception support
+ */
+void *sml_exn_init(void);
+void sml_exn_free(void *);
+void sml_exn_enum_ptr(void *,  void (*)(void **));
+void sml_uncaught_exn(void *) ATTR_NORETURN;
+void sml_matchcomp_bug(void) ATTR_NORETURN;
+
+SML_PRIMITIVE void sml_raise(void *exn) ATTR_NORETURN;
+/*
+_Unwind_Reason_Code
+sml_personality(int version, _Unwind_Action actions, uint64_t exnclass,
+		struct _Unwind_Exception *exception,
+		struct _Unwind_Context *context);
+*/
+
+/*
+ * synchronizations
+ */
+typedef struct sml_event sml_event_t;
+sml_event_t *sml_event_new(int no_reset, int init);
+void sml_event_free(sml_event_t *event);
+void sml_event_wait(sml_event_t *event);
+void sml_event_signal(sml_event_t *event);
+void sml_event_reset(sml_event_t *event);
+
+typedef struct sml_counter sml_counter_t;
+sml_counter_t *sml_counter_new(void);
+void sml_counter_free(sml_counter_t *c);
+void sml_counter_inc(struct sml_counter *c);
+void sml_counter_wait(struct sml_counter *c, int min);
+
+/*
+ * Initialize and finalize SML# runtime
+ */
+void sml_init(int argc, char **argv);
+void sml_finish(void);
+
+#endif /* SMLSHARP__SMLSHARP_H__ */

--- a/lib/ext/Std.smi
+++ b/lib/ext/Std.smi
@@ -1,3 +1,6 @@
+_require "basis.smi"
+_require "ffi.smi"
+
 infixr 0 $
 
 structure Std = struct
@@ -7,6 +10,8 @@ structure Std = struct
   val curry : ('a * 'b -> 'c) -> 'a -> 'b -> 'c
   val uncurry : ('a -> 'b -> 'c) -> 'a * 'b -> 'c
   val const : 'a -> 'b -> 'a
+
+  val dump : 'a -> unit
 
   val version : (int * int * int)
   val version_string : string

--- a/lib/ext/Std.sml
+++ b/lib/ext/Std.sml
@@ -1,3 +1,6 @@
+val c_dump =
+  _import "c_dump" : 'a array -> ()
+
 structure Std = struct
   fun id x = x
   fun op $ (f, x) = f x
@@ -5,6 +8,9 @@ structure Std = struct
   fun curry f x y = f (x, y)
   fun uncurry f (x, y) = f x y
   fun const x _ = x
+
+  fun dump x =
+    c_dump (Array.array (1, x))
 
   val version = (0,1,0)
   val version_string = "0.1.0"

--- a/lib/ext/Std_support.c
+++ b/lib/ext/Std_support.c
@@ -19,46 +19,29 @@ static void obj_dump__(int indent, void *obj)
   switch (OBJ_TYPE(obj)) {
     case OBJTYPE_UNBOXED_ARRAY:
     case OBJTYPE_UNBOXED_VECTOR:
-      if (indent == 0) {
-        for (i = 0; i < OBJ_SIZE(obj) / sizeof(unsigned int); i++)
-          printf("%*s0x%08x\n",
-              0, "", ((unsigned int *)field)[i]);
-        for (i = i * sizeof(unsigned int); i < OBJ_SIZE(obj); i++)
-          printf("%*s0x%02x\n",
-              0, "", ((unsigned char*)field)[i]);
-      } else {
-        printf("%*s%p:%u:%s\n",
-            indent, "", obj, OBJ_SIZE(obj),
-            (OBJ_TYPE(obj) == OBJTYPE_UNBOXED_ARRAY)
-            ? "UNBOXED_ARRAY" : "UNBOXED_VECTOR");
-        for (i = 0; i < OBJ_SIZE(obj) / sizeof(unsigned int); i++)
-          printf("%*s0x%08x\n",
-              indent + 2, "", ((unsigned int *)field)[i]);
-        for (i = i * sizeof(unsigned int); i < OBJ_SIZE(obj); i++)
-          printf("%*s0x%02x\n",
-              indent + 2, "", ((unsigned char*)field)[i]);
-      }
+      printf("%*s%p:%u:%s\n",
+          indent, "", obj, OBJ_SIZE(obj),
+          (OBJ_TYPE(obj) == OBJTYPE_UNBOXED_ARRAY)
+          ? "UNBOXED_ARRAY" : "UNBOXED_VECTOR");
+      for (i = 0; i < OBJ_SIZE(obj) / sizeof(unsigned int); i++)
+        printf("%*s0x%08x\n",
+            indent + 2, "", ((unsigned int *)field)[i]);
+      for (i = i * sizeof(unsigned int); i < OBJ_SIZE(obj); i++)
+        printf("%*s0x%02x\n",
+            indent + 2, "", ((unsigned char*)field)[i]);
       break;
 
     case OBJTYPE_BOXED_ARRAY:
     case OBJTYPE_BOXED_VECTOR:
-      if (indent == 0) {
-        for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++)
-          obj_dump__(0, field[i]);
-        for (i = i * sizeof(void*); i < OBJ_SIZE(obj); i++)
-          printf("%*s0x%02x\n",
-              0, "", ((char*)field)[i]);
-      } else {
-        printf("%*s%p:%u:%s\n",
-            indent, "", obj, OBJ_SIZE(obj),
-            (OBJ_TYPE(obj) == OBJTYPE_BOXED_ARRAY)
-            ? "BOXED_ARRAY" : "BOXED_VECTOR");
-        for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++)
-          obj_dump__(indent + 2, field[i]);
-        for (i = i * sizeof(void*); i < OBJ_SIZE(obj); i++)
-          printf("%*s0x%02x\n",
-              indent + 2, "", ((char*)field)[i]);
-      }
+      printf("%*s%p:%u:%s\n",
+          indent, "", obj, OBJ_SIZE(obj),
+          (OBJ_TYPE(obj) == OBJTYPE_BOXED_ARRAY)
+          ? "BOXED_ARRAY" : "BOXED_VECTOR");
+      for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++)
+        obj_dump__(indent + 2, field[i]);
+      for (i = i * sizeof(void*); i < OBJ_SIZE(obj); i++)
+        printf("%*s0x%02x\n",
+            indent + 2, "", ((char*)field)[i]);
       break;
 
     case OBJTYPE_RECORD:
@@ -87,6 +70,35 @@ static void obj_dump__(int indent, void *obj)
   }
 }
 
+static void first_array_dump(void *obj)
+{
+  unsigned int i;
+  void **field = obj;
+
+  switch (OBJ_TYPE(obj)) {
+    case OBJTYPE_UNBOXED_ARRAY:
+    case OBJTYPE_UNBOXED_VECTOR:
+      for (i = 0; i < OBJ_SIZE(obj) / sizeof(unsigned int); i++)
+        printf("%*s0x%08x\n", 0, "", ((unsigned int *)field)[i]);
+      for (i = i * sizeof(unsigned int); i < OBJ_SIZE(obj); i++)
+        printf("%*s0x%02x\n", 0, "", ((unsigned char*)field)[i]);
+      break;
+
+    case OBJTYPE_BOXED_ARRAY:
+    case OBJTYPE_BOXED_VECTOR:
+      for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++)
+        obj_dump__(0, field[i]);
+      for (i = i * sizeof(void*); i < OBJ_SIZE(obj); i++)
+        printf("%*s0x%02x\n", 0, "", ((char*)field)[i]);
+      break;
+
+    default:
+      printf("%*s%p:%u:unknown type %u",
+          0, "", obj, OBJ_SIZE(obj), OBJ_TYPE(obj));
+      break;
+  }
+}
+
 void c_dump(void* p, size_t size) {
-  obj_dump__(0, p);
+  first_array_dump(p);
 }

--- a/lib/ext/Std_support.c
+++ b/lib/ext/Std_support.c
@@ -1,0 +1,75 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <smlsharp.h>
+#include <intinf.h>
+#include <object.h>
+
+static void obj_dump__(int indent, void *obj)
+{
+  unsigned int i;
+  unsigned int *bitmap;
+  void **field = obj;
+  char *buf;
+
+  if (obj == NULL) {
+    printf("%*sNULL\n", indent, "");
+    return;
+  }
+
+  switch (OBJ_TYPE(obj)) {
+    case OBJTYPE_UNBOXED_ARRAY:
+    case OBJTYPE_UNBOXED_VECTOR:
+      printf("%*s%p:%u:%s\n",
+          indent, "", obj, OBJ_SIZE(obj),
+          (OBJ_TYPE(obj) == OBJTYPE_UNBOXED_ARRAY)
+          ? "UNBOXED_ARRAY" : "UNBOXED_VECTOR");
+      for (i = 0; i < OBJ_SIZE(obj) / sizeof(unsigned int); i++)
+        printf("%*s0x%08x\n",
+            indent + 2, "", ((unsigned int *)field)[i]);
+      for (i = i * sizeof(unsigned int); i < OBJ_SIZE(obj); i++)
+        printf("%*s0x%02x\n",
+            indent + 2, "", ((unsigned char*)field)[i]);
+      break;
+
+    case OBJTYPE_BOXED_ARRAY:
+    case OBJTYPE_BOXED_VECTOR:
+      printf("%*s%p:%u:%s\n",
+          indent, "", obj, OBJ_SIZE(obj),
+          (OBJ_TYPE(obj) == OBJTYPE_BOXED_ARRAY)
+          ? "BOXED_ARRAY" : "BOXED_VECTOR");
+      for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++)
+        obj_dump__(indent + 2, field[i]);
+      for (i = i * sizeof(void*); i < OBJ_SIZE(obj); i++)
+        printf("%*s0x%02x\n",
+            indent + 2, "", ((char*)field)[i]);
+      break;
+
+    case OBJTYPE_RECORD:
+      printf("%*s%p:%u:RECORD\n",
+          indent, "", obj, OBJ_SIZE(obj));
+      bitmap = OBJ_BITMAP(obj);
+      for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++) {
+        if (BITMAP_BIT(bitmap, i) != TAG_UNBOXED)
+          obj_dump__(indent + 2, field[i]);
+        else
+          printf("%*s%p\n", indent + 2, "", field[i]);
+      }
+      break;
+
+    case OBJTYPE_INTINF:
+      buf = sml_intinf_fmt((sml_intinf_t*)obj, 10);
+      printf("%*s%p:%u:INTINF: %s\n",
+          indent, "", obj, OBJ_SIZE(obj), buf);
+      free(buf);
+      break;
+
+    default:
+      printf("%*s%p:%u:unknown type %u",
+          indent, "", obj, OBJ_SIZE(obj), OBJ_TYPE(obj));
+      break;
+  }
+}
+
+void c_dump(void* p, size_t size) {
+  obj_dump__(0, p);
+}

--- a/lib/ext/Std_support.c
+++ b/lib/ext/Std_support.c
@@ -19,29 +19,46 @@ static void obj_dump__(int indent, void *obj)
   switch (OBJ_TYPE(obj)) {
     case OBJTYPE_UNBOXED_ARRAY:
     case OBJTYPE_UNBOXED_VECTOR:
-      printf("%*s%p:%u:%s\n",
-          indent, "", obj, OBJ_SIZE(obj),
-          (OBJ_TYPE(obj) == OBJTYPE_UNBOXED_ARRAY)
-          ? "UNBOXED_ARRAY" : "UNBOXED_VECTOR");
-      for (i = 0; i < OBJ_SIZE(obj) / sizeof(unsigned int); i++)
-        printf("%*s0x%08x\n",
-            indent + 2, "", ((unsigned int *)field)[i]);
-      for (i = i * sizeof(unsigned int); i < OBJ_SIZE(obj); i++)
-        printf("%*s0x%02x\n",
-            indent + 2, "", ((unsigned char*)field)[i]);
+      if (indent == 0) {
+        for (i = 0; i < OBJ_SIZE(obj) / sizeof(unsigned int); i++)
+          printf("%*s0x%08x\n",
+              0, "", ((unsigned int *)field)[i]);
+        for (i = i * sizeof(unsigned int); i < OBJ_SIZE(obj); i++)
+          printf("%*s0x%02x\n",
+              0, "", ((unsigned char*)field)[i]);
+      } else {
+        printf("%*s%p:%u:%s\n",
+            indent, "", obj, OBJ_SIZE(obj),
+            (OBJ_TYPE(obj) == OBJTYPE_UNBOXED_ARRAY)
+            ? "UNBOXED_ARRAY" : "UNBOXED_VECTOR");
+        for (i = 0; i < OBJ_SIZE(obj) / sizeof(unsigned int); i++)
+          printf("%*s0x%08x\n",
+              indent + 2, "", ((unsigned int *)field)[i]);
+        for (i = i * sizeof(unsigned int); i < OBJ_SIZE(obj); i++)
+          printf("%*s0x%02x\n",
+              indent + 2, "", ((unsigned char*)field)[i]);
+      }
       break;
 
     case OBJTYPE_BOXED_ARRAY:
     case OBJTYPE_BOXED_VECTOR:
-      printf("%*s%p:%u:%s\n",
-          indent, "", obj, OBJ_SIZE(obj),
-          (OBJ_TYPE(obj) == OBJTYPE_BOXED_ARRAY)
-          ? "BOXED_ARRAY" : "BOXED_VECTOR");
-      for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++)
-        obj_dump__(indent + 2, field[i]);
-      for (i = i * sizeof(void*); i < OBJ_SIZE(obj); i++)
-        printf("%*s0x%02x\n",
-            indent + 2, "", ((char*)field)[i]);
+      if (indent == 0) {
+        for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++)
+          obj_dump__(0, field[i]);
+        for (i = i * sizeof(void*); i < OBJ_SIZE(obj); i++)
+          printf("%*s0x%02x\n",
+              0, "", ((char*)field)[i]);
+      } else {
+        printf("%*s%p:%u:%s\n",
+            indent, "", obj, OBJ_SIZE(obj),
+            (OBJ_TYPE(obj) == OBJTYPE_BOXED_ARRAY)
+            ? "BOXED_ARRAY" : "BOXED_VECTOR");
+        for (i = 0; i < OBJ_SIZE(obj) / sizeof(void*); i++)
+          obj_dump__(indent + 2, field[i]);
+        for (i = i * sizeof(void*); i < OBJ_SIZE(obj); i++)
+          printf("%*s0x%02x\n",
+              indent + 2, "", ((char*)field)[i]);
+      }
       break;
 
     case OBJTYPE_RECORD:


### PR DESCRIPTION
任意の型をマジカルに文字列化します。

``` sml
type t = { x : int, y : int }
datatype s = Foo | Bar

val () =
  Std.dump 42;
  Std.dump "foo";
  Std.dump { x = 10, y = 42 };
  Std.dump Foo
```

```
0xe74eaf40:4:UNBOXED_ARRAY
  0x0000002a
0xe74eaf58:4:BOXED_ARRAY
  0x8127f80:4:UNBOXED_VECTOR
    0x006f6f66
0xe74eaf68:4:BOXED_ARRAY
  0x8127f90:8:RECORD
    0xa
    0x2a
0xe74eaf88:4:UNBOXED_ARRAY
  0x00000001
```
## 仕組み

SML# のノースツリーにあるdump関数をコピーして利用しています。

ただ、'aをそのまま、Cの関数に渡すことはできないので、 'a arrayを経由します。
## この仕組みで'a -> 'bは実装できないの?

'a -> 'a array -> 'a ptr -> 'a ptr -> 'a をいう変換はできるけど、'a ptr -> 'a(SMLSharp_builtin.Pointer.deref)でセグメンテーションフォールトがおきる。
## 'a -> stringはできないの?

できる。でも面倒なのでやりたくない。
