### PR TITLE
HTTPパーサのSML# 3.1.0対応及びAPI変更

### DIFF
--- a/lib/http_parser/HttpParser.smi
+++ b/lib/http_parser/HttpParser.smi
@@ -11,7 +11,7 @@ struct
     val parseRequestString: string -> request option
     val parseResponseString: string -> response option
     val parseHeadersString: string -> headers option
-    val decoder: unit -> chunkedDecoder
+    val withDecoder: (chunkedDecoder -> unit) -> unit
     val decodeChunkedCharArray: chunkedDecoder -> CharArray.array -> int -> int ref -> int option
 
 end

--- a/lib/http_parser/HttpParser.smi
+++ b/lib/http_parser/HttpParser.smi
@@ -3,17 +3,15 @@ _require "ffi.smi"
 
 structure HttpParser =
 struct
-exception Parse
-type t(=boxed)
-type chunkedDecoder = unit ptr
-type request = {method: string, path: string, minorVersion: int, headers: (string * string) list, parsedSize: int}
-type response = {minorVersion: int, status: int, message: string, headers: (string * string) list, parsedSize: int}
-val prepareHeaders: int -> t
-val prepareDecoder: unit -> chunkedDecoder
-val parseRequest: t -> string -> request option
-val parseResponse: t -> string -> response option
-val parseHeaders: t -> string -> {headers: (string * string) list, parsedSize: int} option
-val decodeChunked: chunkedDecoder -> CharArray.array -> int -> int ref ->  unit option
-val finalizeHeaders: t -> unit
-val finalizeDecoder: chunkedDecoder -> unit
+    exception Parse
+    type chunkedDecoder( = ptr)
+    type request = {method: Substring.substring, path: Substring.substring, minorVersion: int, headers: (Substring.substring * Substring.substring) list, parsedSize: int}
+    type response = {minorVersion: int, status: int, message: Substring.substring, headers: (Substring.substring * Substring.substring) list, parsedSize: int}
+    type headers = {headers: (Substring.substring * Substring.substring) list, parsedSize: int}
+    val parseRequestString: string -> request option
+    val parseResponseString: string -> response option
+    val parseHeadersString: string -> headers option
+    val decoder: unit -> chunkedDecoder
+    val decodeChunkedCharArray: chunkedDecoder -> CharArray.array -> int -> int ref -> int option
+
 end

--- a/lib/http_parser/HttpParser.sml
+++ b/lib/http_parser/HttpParser.sml
@@ -27,7 +27,7 @@ val c_parse_headers = _import "http_parser_parse_headers":
                       (string, int,
                        (int, int, int, int) -> ()) -> int
 
-val c_decoder = _import "http_parser_decoder": () -> chunkedDecoder
+val c_with_decoder = _import "http_parser_with_decoder": (chunkedDecoder -> ()) -> ()
 val c_decode_chunked = _import "http_parser_decode_chunked": (chunkedDecoder, char array, int , int ref) -> int
 
 val subs = Substring.substring
@@ -118,7 +118,7 @@ in
 end
 
 
-val decoder = c_decoder
+val withDecoder = c_with_decoder
 
 fun decodeChunkedCharArray decoder buf start size =
   case c_decode_chunked(decoder, buf, start, size) of

--- a/lib/http_parser/HttpParser.sml
+++ b/lib/http_parser/HttpParser.sml
@@ -1,206 +1,130 @@
 structure HttpParser =
 struct
 
-type headers = unit ptr
-type t = (headers * int)
+
 type chunkedDecoder = unit ptr
-type request = {method: string, path: string, minorVersion: int, headers: (string * string) list, parsedSize: int}
-type response = {minorVersion: int, status: int, message: string, headers: (string * string) list, parsedSize: int}
+type request = {method: Substring.substring, path: Substring.substring, minorVersion: int, headers: (Substring.substring * Substring.substring) list, parsedSize: int}
+type response = {minorVersion: int, status: int, message: Substring.substring, headers: (Substring.substring * Substring.substring) list, parsedSize: int}
+type headers = {headers: (Substring.substring * Substring.substring) list, parsedSize: int}
+
+
 exception Parse
-exception MemoryFull
 
-val phr_prepare_headers = _import "phr_prepare_headers": __attribute__((no_callback))
-                                                                      int -> headers
 
-val phr_prepare_decoder = _import "phr_prepare_decoder": __attribute__((no_callback))
-                                                                      () -> chunkedDecoder
+val c_parse_request = _import "http_parser_parse_request":
+                      (string, int,
+                       int ref, int ref,
+                       int ref, int ref,
+                       int ref, (int, int, int, int) -> ()) -> int
 
-val phr_finalize_headers = _import "free": __attribute__((no_callback))
-                                                        headers -> ()
-val phr_finalize_decoder = _import "free": __attribute__((no_callback))
-                                                        chunkedDecoder -> ()
+val c_parse_response = _import "http_parser_parse_response":
+                       (string, int,
+                        int ref, int ref,
+                        int ref, int ref,
+                        (int, int, int, int) -> ()) -> int
 
-val phr_parse_request =
-    _import "phr_parse_request":  __attribute__((no_callback))
-                                               (
-                                                 string, int,
-                                                 string ref, int ref,
-                                                 string ref, int ref,
-                                                 int ref,
-                                                 headers, int ref,
-                                                 int
-                                               ) -> int
+val c_parse_headers = _import "http_parser_parse_headers":
+                      (string, int,
+                       (int, int, int, int) -> ()) -> int
 
-val phr_parse_response =
-    _import "phr_parse_response": __attribute__((no_callback))
-                                               (
-                                                 string, int,
-                                                 int ref,
-                                                 int ref, string ref, int ref,
-                                                 headers, int ref,
-                                                 int
-                                               ) -> int
+val c_decoder = _import "http_parser_decoder": () -> chunkedDecoder
+val c_decode_chunked = _import "http_parser_decode_chunked": (chunkedDecoder, char array, int , int ref) -> int
 
-val phr_parse_headers =
-    _import "phr_parse_headers": __attribute__((no_callback))
-                                              (
-                                                string, int,
-                                                headers, int ref,
-                                                int
-                                              ) -> int
+val subs = Substring.substring
 
-val phr_decode_chunked_aux =
-    _import "phr_decode_chunked_aux": __attribute__((no_callback))
-                                               (
-                                                 chunkedDecoder,
-                                                 CharArray.array, int,
-                                                 int ref
-                                               ) -> int
-
-fun prepareHeaders n =
-  let
-      val headers = phr_prepare_headers n
-  in
-      if headers = _NULL
-      then raise MemoryFull
-      else (headers, n)
-  end
-
-fun finalizeHeaders (header, i) = (phr_finalize_headers header; ())
-
-local
+fun parseRequestString str = let
+    val len = String.size(str)
+    val methodStart  = ref 0
+    val methodSize   = ref 0
+    val pathStart    = ref 0
+    val pathSize     = ref 0
+    val minorVersion = ref 0
+    val headers       = ref []
+    fun callback (n, nsz, v, vsz) =
+      if n = ~1
+      then case !headers of
+               (name, value)::tl =>
+               headers := (name, Substring.full((Substring.string value)
+                                                ^ (String.substring(str, v, vsz)))) :: tl
+            | _ => raise Fail "unreachable"
+      else headers := (subs(str, n, nsz), subs(str, v, vsz)) :: (!headers)
+    val ret = c_parse_request(str, len,
+                              methodStart, methodSize,
+                              pathStart, pathSize,
+                              minorVersion, callback)
 in
-val fromUnitPtr = SMLSharp_Builtin.Pointer.fromUnitPtr
-val deref = SMLSharp_Builtin.Pointer.deref
-val toUnitPtr = SMLSharp_Builtin.Pointer.toUnitPtr
-val advance = Pointer.advance
-val importString = Pointer.importString
-val isNull = Pointer.isNull
-fun getHeader (headers, n) i =
-      if 0<=i andalso i < n
-      then let
-          val header_ptr : char ptr ptr = fromUnitPtr(headers)
-          val header_ptr = advance(header_ptr, i * 2)
-          val header_ptr : int ptr =
-              fromUnitPtr(toUnitPtr(header_ptr))
-          val header_ptr = advance(header_ptr , i * 2)
-
-          val header_ptr : char ptr ptr =
-              fromUnitPtr(toUnitPtr(header_ptr))
-          val name = deref(header_ptr)
-          val header_ptr = advance(header_ptr, 1)
-
-          val header_ptr : int ptr =
-              fromUnitPtr(toUnitPtr(header_ptr))
-          val nameLen = deref(header_ptr)
-          val header_ptr = advance(header_ptr, 1)
-
-          val header_ptr : char ptr ptr =
-              fromUnitPtr(toUnitPtr(header_ptr))
-          val value = deref(header_ptr)
-          val header_ptr = advance(header_ptr, 1)
-
-          val header_ptr : int ptr =
-              fromUnitPtr(toUnitPtr(header_ptr))
-          val valueLen = deref(header_ptr)
-      in
-          if isNull name
-          then (NONE, String.substring(importString(value), 0, valueLen))
-          else (SOME(String.substring(importString(name), 0, nameLen)),
-                String.substring(importString(value), 0, valueLen))
-      end
-      else  raise Subscript
+    case ret of
+        ~1 => raise Parse
+      | ~2 => NONE
+      | parsedSize => SOME ({
+                               method       = subs(str, !methodStart, !methodSize),
+                               path         = subs(str, !pathStart,   !pathSize),
+                               minorVersion = !minorVersion,
+                               headers      = List.rev (!headers),
+                               parsedSize   = parsedSize
+                           })
 end
 
-fun prepareDecoder () =
-  let
-      val decoder = phr_prepare_decoder()
-  in
-      if decoder = _NULL
-      then raise MemoryFull
-      else decoder
-  end
+fun parseResponseString str = let
+    val len = String.size(str)
+    val minorVersion = ref 0
+    val status = ref 0
+    val msgStart  = ref 0
+    val msgSize   = ref 0
+    val headers       = ref []
+    fun callback (n, nsz, v, vsz) =
+      if n = ~1
+      then case !headers of
+               (name, value)::tl =>
+               headers := (name, Substring.full((Substring.string value)
+                                                ^ (String.substring(str, v, vsz)))) :: tl
+             | _ => raise Fail "unreachable"
+      else headers := (subs(str, n, nsz), subs(str, v, vsz)) :: (!headers)
+    val ret = c_parse_response(str, len, minorVersion, status,
+                               msgStart, msgSize, callback)
+in
+    case ret of
+        ~1 => raise Parse
+      | ~2 => NONE
+      | parsedSize => SOME ({
+                               message  = subs(str, !msgStart, !msgSize),
+                               status = !status,
+                               minorVersion = !minorVersion,
+                               headers      = List.rev (!headers),
+                               parsedSize   = parsedSize
+                           })
+end
 
-fun finalizeDecoder decoder = (phr_finalize_decoder decoder; ())
+fun parseHeadersString str = let
+    val len = String.size(str)
+    val headers       = ref []
+    fun callback (n, nsz, v, vsz) =
+      if n = ~1
+      then case !headers of
+               (name, value)::tl =>
+               headers := (name, Substring.full((Substring.string value)
+                                                ^ (String.substring(str, v, vsz)))) :: tl
+             | _ => raise Fail "unreachable"
+      else headers := (subs(str, n, nsz), subs(str, v, vsz)) :: (!headers)
+    val ret = c_parse_headers(str, len,  callback)
+in
+    case ret of
+        ~1 => raise Parse
+      | ~2 => NONE
+      | parsedSize => SOME ({
+                               headers      = List.rev (!headers),
+                               parsedSize   = parsedSize
+                           })
+end
 
-fun getHeaders headers n =
-  let
-      fun loop i acc =
-        if i = n
-        then acc
-        else loop (i + 1) ((getHeader headers i) :: acc)
 
-      fun maybeAppend str1 (SOME str2) = str1 ^ str2
-        | maybeAppend str1 (NONE) = str1
-  in
-      #1 (List.foldl (fn ((name, value), (acc, value_acc))=>
-                         case name of
-                             NONE => (acc, SOME(maybeAppend value value_acc))
-                           | SOME name' => ((name', maybeAppend value value_acc):: acc, NONE))
-                     ([], NONE) (loop 0 []))
-  end
-      
-fun parseRequest (t as (headers, n)) buf =
-  let
-      val bufLen = String.size(buf)
-      val method = ref ""
-      val methodLen = ref 0
-      val path = ref ""
-      val pathLen = ref 0
-      val minorVersion = ref 0
-      val numHeaders = ref n
-  in
-      case phr_parse_request(buf, bufLen, method, methodLen, path, pathLen,
-                             minorVersion, headers, numHeaders, 0) of
-          ~1 => raise Parse
-        | ~2 => NONE
-        | x => SOME{
-                  method = String.substring(!method, 0, !methodLen),
-                  path = String.substring(!path, 0, !pathLen),
-                  minorVersion = !minorVersion,
-                  headers = getHeaders (headers, n) (!numHeaders),
-                  parsedSize = x
-              }
-  end
+val decoder = c_decoder
 
-fun parseResponse (t as (headers, n)) buf =
-  let
-      val bufLen = String.size(buf)
-      val minorVersion = ref 0
-      val status = ref 0
-      val msg = ref ""
-      val msgLen = ref 0
-      val numHeaders = ref n
-  in
-      case phr_parse_response(buf, bufLen, minorVersion, status, msg, msgLen,
-                              headers, numHeaders, 0) of
-          ~1 => raise Parse
-        | ~2 => NONE
-        | x  => SOME{
-                   minorVersion = !minorVersion,
-                   status = !status,
-                   message = String.substring(!msg, 0, !msgLen),
-                   headers = getHeaders t (!numHeaders),
-                   parsedSize = x
-               }
-  end
-
-fun parseHeaders (t as (headers, n)) buf =
-  let
-      val bufLen = String.size(buf)
-      val numHeaders = ref n
-  in
-      case phr_parse_headers(buf, bufLen, headers, numHeaders, 0) of
-          ~1 => raise Parse
-        | ~2 => NONE
-        | x  => SOME{headers = (getHeaders t (!numHeaders)), parsedSize = x}
-  end
-
-fun decodeChunked decoder buf start size =
-  case phr_decode_chunked_aux(decoder, buf, start, size) of
+fun decodeChunkedCharArray decoder buf start size =
+  case c_decode_chunked(decoder, buf, start, size) of
       ~1 => raise Parse
     | ~2 => NONE
-    | x  => SOME()
+    | x  => SOME(x)
 
 
 end

--- a/lib/http_parser/HttpParser_Support.c
+++ b/lib/http_parser/HttpParser_Support.c
@@ -96,15 +96,14 @@ http_parser_parse_headers(const char *buf, size_t len,
 
 
 
-struct phr_chunked_decoder
-*http_parser_decoder()
-{
-  struct phr_chunked_decoder *decoder;
 
-  decoder =  malloc(sizeof(*decoder));
-  if(decoder)
-    memset(decoder, 0, sizeof(*decoder));
-  return decoder;
+void
+http_parser_with_decoder(void (callback)(struct phr_chunked_decoder*))
+{
+  struct phr_chunked_decoder decoder;
+
+  memset(&decoder, 0, sizeof(decoder));
+  callback(&decoder);
 }
 
 size_t

--- a/lib/http_parser/HttpParser_Support.c
+++ b/lib/http_parser/HttpParser_Support.c
@@ -2,14 +2,102 @@
 #include <string.h>
 #include "picohttpparser.h"
 
-struct phr_header
-*phr_prepare_headers(int n)
+int
+http_parser_parse_request(const char *buf, size_t len,
+                          size_t* method_start, size_t* method_len,
+                          size_t* path_start, size_t* path_len,
+                          int* minor_version,
+                          void (callback)(int, size_t, int, size_t))
 {
-  return malloc(sizeof(struct phr_header) * n);
+  struct phr_header header, headers[100];
+  const char *method, *path;
+  int ret;
+  size_t nheaders, i;
+
+
+  nheaders = sizeof(headers)/sizeof(headers[0]);
+
+  ret = phr_parse_request(buf, len,
+                          &method, method_len,
+                          &path, path_len,
+                          minor_version,
+                          headers, &nheaders, 0);
+  if (ret < 0) {
+    return ret;
+  }
+
+  *method_start = (size_t)(method - buf);
+  *path_start   = (size_t)(path   - buf);
+
+  for (i = 0; i < nheaders; i += 1) {
+    header = headers[i];
+    callback(header.name ?(int)(header.name - buf) : -1, header.name_len,
+             (int)(header.value - buf), header.value_len);
+  }
+  return ret;
 }
 
+int
+http_parser_parse_response(const char *buf, size_t len,
+                           int* minor_version,
+                           int* status,
+                           size_t *msg_start, size_t *msg_len,
+                           void (callback)(size_t, size_t, size_t, size_t))
+{
+  struct phr_header header, headers[100];
+  const char *msg;
+  int ret;
+  size_t nheaders, i;
+
+  nheaders = sizeof(headers)/sizeof(headers[0]);
+
+  ret = phr_parse_response(buf, len,
+                           minor_version,
+                           status,
+                           &msg, msg_len,
+                           headers, &nheaders, 0);
+  if (ret < 0) {
+    return ret;
+  }
+
+  *msg_start = (size_t)(msg - buf);
+
+  for (i = 0; i < nheaders; i += 1) {
+    header = headers[i];
+    callback(header.name?(int)(header.name - buf):-1, header.name_len,
+             (int)(header.value - buf), header.value_len);
+  }
+  return ret;
+}
+
+int
+http_parser_parse_headers(const char *buf, size_t len,
+                           void (callback)(int, size_t, int, size_t))
+{
+  struct phr_header header, headers[100];
+  int ret;
+  size_t nheaders, i;
+
+  nheaders = sizeof(headers)/sizeof(headers[0]);
+
+  ret = phr_parse_headers(buf, len,
+                           headers, &nheaders, 0);
+  if (ret < 0) {
+    return ret;
+  }
+
+  for (i = 0; i < nheaders; i += 1) {
+    header = headers[i];
+    callback(header.name?(int)(header.name - buf):-1, header.name_len,
+             (int)(header.value - buf), header.value_len);
+  }
+  return ret;
+}
+
+
+
 struct phr_chunked_decoder
-*phr_prepare_decoder()
+*http_parser_decoder()
 {
   struct phr_chunked_decoder *decoder;
 
@@ -19,8 +107,8 @@ struct phr_chunked_decoder
   return decoder;
 }
 
-ssize_t
-phr_decode_chunked_aux(struct phr_chunked_decoder *decoder, char *buf, int start, size_t *size)
+size_t
+http_parser_decode_chunked(struct phr_chunked_decoder *decoder, char *buf, int start, size_t *size)
 {
   return phr_decode_chunked(decoder, buf + start, size);
 }

--- a/test/http_parser/HttpParserTest.sml
+++ b/test/http_parser/HttpParserTest.sml
@@ -3,22 +3,26 @@ open SMLUnit
 open HttpParser
 open Assert
 
-val assertEqualHeader =
-    assertEqualList(assertEqual2Tuple(assertEqualString,
-                                      assertEqualString))
+val hToString = List.map (fn (n, v) => (Substring.string n, Substring.string v))
+
+fun assertEqualHeader expected actual =
+  assertEqualList(assertEqual2Tuple(assertEqualString,
+                                    assertEqualString))
+                 expected
+                 (hToString actual)
 
 fun assertHeaderParsed expected actual =
   (assertSome actual;
    assertEqualHeader (#headers expected) (#headers (Option.valOf actual)))
-    
+
 fun assertRequestParsed expected actual =
   (assertSome actual;
    let
        val a = Option.valOf actual
        val e = expected
    in
-       assertEqualString (#method e)       (#method a);
-       assertEqualString (#path e)         (#path a);
+       assertEqualString (#method e)       (Substring.string(#method a));
+       assertEqualString (#path e)         (Substring.string(#path a));
        assertEqualInt    (#minorVersion e) (#minorVersion a);
        assertEqualHeader (#headers e)      (#headers a)
    end
@@ -32,33 +36,40 @@ fun assertResponseParsed expected actual =
    in
        assertEqualInt (#minorVersion e) (#minorVersion a);
        assertEqualInt (#status e) (#status a);
-       assertEqualString (#message e) (#message a);
+       assertEqualString (#message e) (Substring.string (#message a));
        assertEqualHeader (#headers e) (#headers a)
    end
   )
 
-fun assertParseError thunk =
+fun assertRequestParseError thunk =
   let val  _ = thunk () in fail "exception didn't occured" end
   handle x => assertEqualExceptionName Parse x
 
-fun assertIncomplete actual = assertNone actual
+fun assertResponseParseError thunk =
+  let val  _ = thunk () in fail "exception didn't occured" end
+  handle x => assertEqualExceptionName Parse x
 
-val headerArray = (prepareHeaders 100)
-val parseRequest' = parseRequest headerArray
-val parseResponse' = parseResponse headerArray
-val parseHeaders' = parseHeaders headerArray
+fun assertHeadersParseError thunk =
+  let val  _ = thunk () in fail "exception didn't occured" end
+  handle x => assertEqualExceptionName Parse x
+
+
+fun assertRequestIncomplete actual = assertNone actual
+fun assertResponseIncomplete actual = assertNone actual
+fun assertHeadersIncomplete actual = assertNone actual
+
 
 val requestTests = [
     ("simple",
      fn () => assertRequestParsed
                   {method = "GET", path = "/", minorVersion = 0, headers = []}
-                  (parseRequest' "GET / HTTP/1.0\r\n\r\n")),
+                  (parseRequestString "GET / HTTP/1.0\r\n\r\n")),
     ("partial",
-     fn () => assertIncomplete (parseRequest' "GET / HTTP/1.0\r\n\r")),
+     fn () => assertRequestIncomplete (parseRequestString "GET / HTTP/1.0\r\n\r")),
     ("parse headers",
      fn () => assertRequestParsed
                   {method = "GET", path = "/hoge", minorVersion = 1, headers = [("Host", "example.com"), ("Cookie", "")]}
-                  (parseRequest' "GET /hoge HTTP/1.1\r\nHost: example.com\r\nCookie: \r\n\r\n")),
+                  (parseRequestString "GET /hoge HTTP/1.1\r\nHost: example.com\r\nCookie: \r\n\r\n")),
     (* ("multibyte included", *)
     (*  fn () => assertRequestParsed *)
     (*              {method = "GET", path = "/hoge", minorVersion = 1, headers = [("Host", "example.com"), ("User-Agent", "\343\201\262\343/1.0")]} *)
@@ -66,139 +77,139 @@ val requestTests = [
     ("parse multiline",
      fn () => assertRequestParsed
                   {method = "GET", path = "/", minorVersion = 0, headers = [("foo", ""), ("foo", "b  \tc")]}
-                  (parseRequest' "GET / HTTP/1.0\r\nfoo: \r\nfoo: b\r\n  \tc\r\n\r\n")),
+                  (parseRequestString "GET / HTTP/1.0\r\nfoo: \r\nfoo: b\r\n  \tc\r\n\r\n")),
     ("http header name with trailing space",
      fn () => assertRequestParsed
                   {method = "GET", path = "/", minorVersion = 0, headers = [("foo ", "ab")]}
-                  (parseRequest' "GET / HTTP/1.0\r\nfoo : ab\r\n\r\n")),
+                  (parseRequestString "GET / HTTP/1.0\r\nfoo : ab\r\n\r\n")),
     ("incomplete 1",
-     fn () => assertIncomplete (parseRequest' "GET")),
+     fn () => assertRequestIncomplete (parseRequestString "GET")),
     ("incomplete 2",
-     fn () => assertIncomplete (parseRequest' "GET ")),
+     fn () => assertRequestIncomplete (parseRequestString "GET ")),
     ("incomplete 3",
-     fn () => assertIncomplete (parseRequest' "GET /")),
+     fn () => assertRequestIncomplete (parseRequestString "GET /")),
     ("incomplete 4",
-     fn () => assertIncomplete (parseRequest' "GET / ")),
+     fn () => assertRequestIncomplete (parseRequestString "GET / ")),
     ("incomplete 5",
-     fn () => assertIncomplete (parseRequest' "GET / H")),
+     fn () => assertRequestIncomplete (parseRequestString "GET / H")),
     ("incomplete 6",
-     fn () => assertIncomplete (parseRequest' "GET / HTTP/1.")),
+     fn () => assertRequestIncomplete (parseRequestString "GET / HTTP/1.")),
     ("incomplete 7",
-     fn () => assertIncomplete (parseRequest' "GET / HTTP/1.0")),
+     fn () => assertRequestIncomplete (parseRequestString "GET / HTTP/1.0")),
     ("incomplete 8",
-     fn () => assertIncomplete (parseRequest' "GET / HTTP/1.0\r")),
+     fn () => assertRequestIncomplete (parseRequestString "GET / HTTP/1.0\r")),
     ("slowloris (incomplete)",
-     fn () => assertIncomplete (parseRequest' "GET /hoge HTTP/1.0\r\n\r")),
+     fn () => assertRequestIncomplete (parseRequestString "GET /hoge HTTP/1.0\r\n\r")),
     ("slowloris (complete)",
      fn () => assertRequestParsed
                   {method = "GET", path = "/hoge", minorVersion = 0, headers = []}
-                  (parseRequest' "GET /hoge HTTP/1.0\r\n\r\n")),
+                  (parseRequestString "GET /hoge HTTP/1.0\r\n\r\n")),
     ("empty header name",
-     fn () => assertParseError (fn () => parseRequest' "GET / HTTP/1.0\r\n:a\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "GET / HTTP/1.0\r\n:a\r\n\r\n")),
     ("header name (space only)",
-     fn () => assertParseError (fn () => parseRequest' "GET / HTTP/1.0\r\n :a\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "GET / HTTP/1.0\r\n :a\r\n\r\n")),
     ("NUL in method",
-     fn () => assertParseError (fn () => parseRequest' "G\000T / HTTP/1.0\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "G\000T / HTTP/1.0\r\n\r\n")),
     ("tab in method",
-     fn () => assertParseError (fn () => parseRequest' "G\tT / HTTP/1.0\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "G\tT / HTTP/1.0\r\n\r\n")),
     ("DEL in uri-path",
-     fn () => assertParseError (fn () => parseRequest' "GET /\127hello HTTP/1.0\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "GET /\127hello HTTP/1.0\r\n\r\n")),
     ("NUL in header name",
-     fn () => assertParseError (fn () => parseRequest' "GET / HTTP/1.0\r\na\000b: c\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "GET / HTTP/1.0\r\na\000b: c\r\n\r\n")),
     ("NUL in header value",
-     fn () => assertParseError (fn () => parseRequest' "GET / HTTP/1.0\r\nab: c\000d\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "GET / HTTP/1.0\r\nab: c\000d\r\n\r\n")),
     ("CTL in header name",
-     fn () => assertParseError (fn () => parseRequest' "GET / HTTP/1.0\r\na\027b: c\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "GET / HTTP/1.0\r\na\027b: c\r\n\r\n")),
     ("CTL in header value",
-     fn () => assertParseError (fn () => parseRequest' "GET / HTTP/1.0\r\nab: c\027\r\n\r\n")),
+     fn () => assertRequestParseError (fn () => parseRequestString "GET / HTTP/1.0\r\nab: c\027\r\n\r\n")),
     ("accept MSB chars",
      fn () => assertRequestParsed
                   {method = "GET", path = "/\160", minorVersion = 0, headers = [("h", "c\162y")]}
-                  (parseRequest' "GET /\160 HTTP/1.0\r\nh: c\162y\r\n\r\n"))
+                  (parseRequestString "GET /\160 HTTP/1.0\r\nh: c\162y\r\n\r\n"))
 ]
 
 val responseTests = [
     ("simple",
      fn () => assertResponseParsed
                   {minorVersion = 0, status = 200, message = "OK", headers = []}
-                  (parseResponse' "HTTP/1.0 200 OK\r\n\r\n")),
+                  (parseResponseString "HTTP/1.0 200 OK\r\n\r\n")),
     ("partial",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.0 200 OK\r\n\r")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.0 200 OK\r\n\r")),
     ("parse headers",
      fn () => assertResponseParsed
                   {minorVersion = 1, status = 200, message = "OK", headers = [("Host", "example.com"), ("Cookie", "")]}
-                  (parseResponse'"HTTP/1.1 200 OK\r\nHost: example.com\r\nCookie: \r\n\r\n")),
+                  (parseResponseString"HTTP/1.1 200 OK\r\nHost: example.com\r\nCookie: \r\n\r\n")),
     ("parse multiline",
      fn () => assertResponseParsed
                   {minorVersion = 0, status = 200, message = "OK", headers = [("foo", ""), ("foo", "b  \tc")]}
-                  (parseResponse'"HTTP/1.0 200 OK\r\nfoo: \r\nfoo: b\r\n  \tc\r\n\r\n")),
+                  (parseResponseString "HTTP/1.0 200 OK\r\nfoo: \r\nfoo: b\r\n  \tc\r\n\r\n")),
     ("internal server error",
      fn () => assertResponseParsed
                   {minorVersion = 0, status = 500, message = "Internal Server Error", headers = []}
-                  (parseResponse'"HTTP/1.0 500 Internal Server Error\r\n\r\n")),
+                  (parseResponseString "HTTP/1.0 500 Internal Server Error\r\n\r\n")),
     ("incomplete 1",
-     fn () => assertIncomplete (parseResponse' "H")),
+     fn () => assertResponseIncomplete (parseResponseString "H")),
     ("incomplete 2",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.")),
     ("incomplete 3",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1")),
     ("incomplete 4",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 ")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 ")),
     ("incomplete 5",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 2")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 2")),
     ("incomplete 6",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 200")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 200")),
     ("incomplete 7",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 200 ")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 200 ")),
     ("incomplete 8",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 200 O")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 200 O")),
     ("incomplete 9",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 200 OK\r")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 200 OK\r")),
     ("incomplete 10",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 200 OK\r\n")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 200 OK\r\n")),
     ("incomplete 11",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 200 OK\n")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 200 OK\n")),
     ("incomplete 11",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 200 OK\r\nA: 1\r")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 200 OK\r\nA: 1\r")),
     ("incomplete 12",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.1 200 OK\r\nA: 1\r\n")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.1 200 OK\r\nA: 1\r\n")),
     ("slowloris (incomplete)",
-     fn () => assertIncomplete (parseResponse' "HTTP/1.0 200 OK\r\n\r")),
+     fn () => assertResponseIncomplete (parseResponseString "HTTP/1.0 200 OK\r\n\r")),
     ("slowloris (complete)",
      fn () => assertResponseParsed
                   {minorVersion = 0, status = 200, message = "OK", headers = []}
-                  (parseResponse' "HTTP/1.0 200 OK\r\n\r\n")),
+                  (parseResponseString "HTTP/1.0 200 OK\r\n\r\n")),
     ("invalid http version",
-     fn () => assertParseError (fn () => (parseResponse' "HTTP/1. 200 OK\r\n\r\n"))),
+     fn () => assertResponseParseError (fn () => (parseResponseString "HTTP/1. 200 OK\r\n\r\n"))),
     ("invalid http version 2",
-     fn () => assertParseError (fn () => (parseResponse' "HTTP/1.2z 200 OK\r\n\r\n"))),
+     fn () => assertResponseParseError (fn () => (parseResponseString "HTTP/1.2z 200 OK\r\n\r\n"))),
     ("no status code",
-     fn () => assertParseError (fn () => (parseResponse' "HTTP/1.1  OK\r\n\r\n")))
+     fn () => assertResponseParseError (fn () => (parseResponseString "HTTP/1.1  OK\r\n\r\n")))
 ]
 
 val headersTest = [
     ("simple",
      fn () => assertHeaderParsed
                   {headers = [("Host", "example.com"), ("Cookie", "")]}
-                  (parseHeaders' "Host: example.com\r\nCookie: \r\n\r\n")),
+                  (parseHeadersString "Host: example.com\r\nCookie: \r\n\r\n")),
     ("slowloris",
      fn () => assertHeaderParsed
                   {headers = [("Host", "example.com"), ("Cookie", "")]}
-                  (parseHeaders' "Host: example.com\r\nCookie: \r\n\r\n")),
+                  (parseHeadersString "Host: example.com\r\nCookie: \r\n\r\n")),
     ("partial",
-     fn () => assertIncomplete (parseHeaders' "Host: example.com\r\nCookie: \r\n\r")),
+     fn () => assertHeadersIncomplete (parseHeadersString "Host: example.com\r\nCookie: \r\n\r")),
     ("error",
-     fn () => assertParseError (fn () => parseHeaders' "Host: e\127ample.com\r\nCookie: \r\n\r"))
+     fn () => assertHeadersParseError (fn () => parseHeadersString "Host: e\127ample.com\r\nCookie: \r\n\r"))
 ]
 
 fun decodeAtOnce str =
   let
-      val decoder = prepareDecoder()
+      val decoder = decoder()
       val size = ref(String.size(str))
       val arr = CharArray.array(!size, #"\000");
   in
       CharArray.copyVec {di = 0, dst = arr, src = str};
-      case decodeChunked decoder arr 0 size of
+      case decodeChunkedCharArray decoder arr 0 size of
           NONE => str
         | SOME _ => let
             val vec = CharArray.vector arr

--- a/test/http_parser/HttpParserTest.sml
+++ b/test/http_parser/HttpParserTest.sml
@@ -204,18 +204,19 @@ val headersTest = [
 
 fun decodeAtOnce str =
   let
-      val decoder = decoder()
       val size = ref(String.size(str))
       val arr = CharArray.array(!size, #"\000");
+      val ret = ref ""
   in
       CharArray.copyVec {di = 0, dst = arr, src = str};
-      case decodeChunkedCharArray decoder arr 0 size of
-          NONE => str
-        | SOME _ => let
-            val vec = CharArray.vector arr
-        in
-            String.substring(vec, 0, !size)
-        end
+      withDecoder (fn decoder => case decodeChunkedCharArray decoder arr 0 size of
+                                     NONE => ret := str
+                                   | SOME _ => let
+                                       val vec = CharArray.vector arr
+                                   in
+                                       ret := String.substring(vec, 0, !size)
+                                   end);
+      !ret
   end
 
 val chunkedDecoderTest = [


### PR DESCRIPTION
- SML# 3.1.0でhttpパーサがビルド出来ない問題を修正
- FFIの使い方に馴れてきたので素直なAPIを作れるように
